### PR TITLE
Adding release pipeline for Helm chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,5 +35,5 @@ jobs:
       - name: Push Helm chart to ECR
         run: |
           CHART_FILE=$(ls packaged/*.tgz)
-          helm push "$CHART_FILE" oci://${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-1.amazonaws.com/cofide/helm-charts/cofide-agent
+          helm push "$CHART_FILE" oci://${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-1.amazonaws.com/cofide/helm-charts
 


### PR DESCRIPTION
Adds a release action for the `cofide-agent` Helm chart. Some notes

* The tag is set in `Chart.yaml` rather than at the Github releases level. We might want to investigate [`chart-releaser`](https://github.com/helm/chart-releaser) or similar in the future, but this is a simple, working approach for the moment.
* Releases are cut from a manual invocation of `workflow_dispatch`

Perhaps we don't want to use an overall release tag for this repo as we're probably housing all our charts here and these will likely develop at different rates. Tag versioning in each `Chart.yaml` seems like a simple first step

---

Try this out with no `--values`:

```
$ helm install cofide-agent oci://010438484483.dkr.ecr.eu-west-1.amazonaws.com/cofide/helm-charts/cofide-agent --namespace cofide --create-namespace
```

Works with a values run from the plugin branch too

```
💤 cofide-connect/ helm install cofide-agent oci://010438484483.dkr.ecr.eu-west-1.amazonaws.com/cofide/helm-charts/cofide-agent --namespace cofide --create-namespace --values a46367e990.yaml 
Pulled: 010438484483.dkr.ecr.eu-west-1.amazonaws.com/cofide/helm-charts/cofide-agent:0.1.0
Digest: sha256:b4023f771b2ed26e6cde3fa533eebbe09f909732352126f69c0bd828049c574a
NAME: cofide-agent
LAST DEPLOYED: Mon Apr 28 13:57:01 2025
NAMESPACE: cofide
STATUS: deployed
REVISION: 1
TEST SUITE: None
```