### PR TITLE
Bumps to v0.19.0

### DIFF
--- a/charts/cofide-agent/Chart.yaml
+++ b/charts/cofide-agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.18.2"
+appVersion: "v0.19.0"


### PR DESCRIPTION
Uprevs to latest Agent version

Note we'll want to introduce some more clever Connect-side handling of Helm chart versions, Agent versions etc to avoid the need for this every release - but this is required to get the CI passing for this connect plugin change https://github.com/cofide/cofidectl-connect-plugin/pull/126