### PR TITLE
Adds federatedservice CRD, uprev to 0.1.3

### DIFF
--- a/charts/cofide-agent/Chart.yaml
+++ b/charts/cofide-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-agent/crds/federatedservices.yaml
+++ b/charts/cofide-agent/crds/federatedservices.yaml
@@ -1,0 +1,146 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: federatedservices.registry.cofide.io
+spec:
+  group: registry.cofide.io
+  names:
+    kind: FederatedService
+    listKind: FederatedServiceList
+    plural: federatedservices
+    singular: federatedservice
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: FederatedService is the Schema for the federatedservices API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              clusterName:
+                type: string
+              exportedTrustDomains:
+                items:
+                  type: string
+                type: array
+              name:
+                type: string
+              namespace:
+                type: string
+              port:
+                format: int32
+                type: integer
+              trustDomain:
+                type: string
+              workloadLabels:
+                additionalProperties:
+                  type: string
+                type: object
+            required:
+            - exportedTrustDomains
+            - name
+            - namespace
+            - port
+            - workloadLabels
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayEntries:
+                items:
+                  properties:
+                    hostname:
+                      type: string
+                    ip:
+                      type: string
+                    port:
+                      format: int32
+                      type: integer
+                    type:
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
* Lift of CRD from cofide-connect https://github.com/cofide/cofide-connect/blob/main/agent/internal/config/crd/bases/registry.cofide.io_federatedservices.yaml
* Bump to 0.1.3 (needs workflow dispatch run after merge for cut)

Local run installs successfully

```
💤 helm-charts/ helm install cofide-agent ~/projects/helm-charts/charts/cofide-agent --namespace cofide --create-namespace
NAME: cofide-agent
LAST DEPLOYED: Fri May  9 13:49:58 2025
NAMESPACE: cofide
STATUS: deployed
REVISION: 1
TEST SUITE: None
💤 helm-charts/ k get crds                                                                   ⎈(kind-user-ad7415ce/default)
NAME                                           CREATED AT
clusterfederatedtrustdomains.spire.spiffe.io   2025-05-09T08:57:45Z
clusterspiffeids.spire.spiffe.io               2025-05-09T08:57:45Z
clusterstaticentries.spire.spiffe.io           2025-05-09T08:57:45Z
federatedservices.registry.cofide.io           2025-05-09T12:50:39Z
```