### PR TITLE
Use canonical labelling, fix JWT issuer protocol

### DIFF
--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -146,12 +146,12 @@ data:
                           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                           providers:
                             ory-oauth:
-                              issuer: https://{{ .Values.envoy.auth.issuer }}
+                              issuer: {{ .Values.envoy.auth.issuer }}
                               audiences:
                                 - https://connect.{{ .Values.connect.urlBase }}
                               remote_jwks:
                                 http_uri:
-                                  uri: https://{{ .Values.envoy.auth.issuer }}/.well-known/jwks.json
+                                  uri: {{ .Values.envoy.auth.issuer }}/.well-known/jwks.json
                                   cluster: jwks_cluster
                                   timeout: 30s
                               claim_to_headers:
@@ -320,13 +320,13 @@ data:
                   - endpoint:
                       address:
                         socket_address:
-                          address: {{ .Values.envoy.auth.issuer }}
+                          address: {{ (urlParse .Values.envoy.auth.issuer).host }}
                           port_value: 443
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
               '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              sni: {{ .Values.envoy.auth.issuer }}
+              sni: {{ (urlParse .Values.envoy.auth.issuer).host }}
               common_tls_context:
                 tls_params:
                   tls_minimum_protocol_version: TLSv1_3

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -146,7 +146,7 @@ data:
                           '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                           providers:
                             ory-oauth:
-                              issuer: {{ .Values.envoy.auth.issuer }}
+                              issuer: https://{{ .Values.envoy.auth.issuer }}
                               audiences:
                                 - https://connect.{{ .Values.connect.urlBase }}
                               remote_jwks:

--- a/charts/cofide-connect/templates/deployment.yaml
+++ b/charts/cofide-connect/templates/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "cofide-connect.labels" . | nindent 6 }}
+      {{- include "cofide-connect.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/charts/cofide-connect/templates/deployment.yaml
+++ b/charts/cofide-connect/templates/deployment.yaml
@@ -8,8 +8,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}
-      {{- include "cofide-connect.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ include "cofide-connect.name" . }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -17,11 +16,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app.kubernetes.io/name: {{ .Release.Name }}
-        {{- include "cofide-connect.labels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        app.kubernetes.io/name: {{ include "cofide-connect.name" . }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/cofide-connect/templates/deployment.yaml
+++ b/charts/cofide-connect/templates/deployment.yaml
@@ -8,7 +8,6 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "cofide-connect.name" . }}
       {{- include "cofide-connect.selectorLabels" . | nindent 6 }}
   template:
     metadata:
@@ -17,7 +16,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app.kubernetes.io/name: {{ include "cofide-connect.name" . }}
+        {{- include "cofide-connect.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/cofide-connect/templates/deployment.yaml
+++ b/charts/cofide-connect/templates/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "cofide-connect.selectorLabels" . | nindent 6 }}
+      {{- include "cofide-connect.labels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -16,7 +16,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "cofide-connect.selectorLabels" . | nindent 8 }}
+        {{- include "cofide-connect.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/cofide-connect/templates/deployment.yaml
+++ b/charts/cofide-connect/templates/deployment.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "cofide-connect.name" . }}
+      {{- include "cofide-connect.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/charts/cofide-connect/templates/service.yaml
+++ b/charts/cofide-connect/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- end }}
   labels:
     {{- include "cofide-connect.labels" . | nindent 4 }}
-  app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "cofide-connect.name" . }}
 spec:
   type: LoadBalancer
   ports:
@@ -17,4 +17,4 @@ spec:
       port: 8443
       targetPort: 8443
   selector:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "cofide-connect.name" . }}

--- a/charts/cofide-connect/templates/service.yaml
+++ b/charts/cofide-connect/templates/service.yaml
@@ -8,7 +8,6 @@ metadata:
   {{- end }}
   labels:
     {{- include "cofide-connect.labels" . | nindent 4 }}
-    app.kubernetes.io/name: {{ include "cofide-connect.name" . }}
 spec:
   type: LoadBalancer
   ports:
@@ -17,4 +16,4 @@ spec:
       port: 8443
       targetPort: 8443
   selector:
-    app.kubernetes.io/name: {{ include "cofide-connect.name" . }}
+    {{- include "cofide-connect.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
* Follows precedent for `/name` labelling (set in default helpers, rather than release name)
* Fixs JWT issuer (doesn't work without https://)

I did look at `urlJoin` for an alternative means to set the issuer, but it seems overly verbose