### PR TITLE
Add Octo STS policy

### DIFF
--- a/.github/chainguard/package.sts.yaml
+++ b/.github/chainguard/package.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:cofide/helm-charts:ref:refs/heads/mb/add-cf-pages-publish
+
+permissions:
+  contents: read
+  packages: write


### PR DESCRIPTION
In order to use the [`octo-sts` action](https://github.com/octo-sts/action), trust policy is required. This policy file defines an identity called `package` with permissions scoped to `contents: read` and `packages: write`. This identity is to be used when publishing the Helm charts to GCHR. 