### PR TITLE
Use separate ConfigMaps for agent config and state

### DIFF
--- a/charts/cofide-agent/Chart.yaml
+++ b/charts/cofide-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-agent/templates/configmap.yaml
+++ b/charts/cofide-agent/templates/configmap.yaml
@@ -1,3 +1,5 @@
+{{- $existingConfigMap := lookup "v1" "ConfigMap" .Release.Namespace "cofide-agent" }}
+{{- if not $existingConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,10 +8,13 @@ data:
 {{- range $key, $value := .Values.agent.env }}
   {{ $key }}: {{ $value | quote }}
 {{- end }}
-
+{{- end }}
 --
 
+{{- $existingConfigMap := lookup "v1" "ConfigMap" .Release.Namespace "cofide-agent-state" }}
+{{- if not $existingConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cofide-agent-state
+{{- end }}

--- a/charts/cofide-agent/templates/configmap.yaml
+++ b/charts/cofide-agent/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cofide-agent-config
+  name: cofide-agent
 data:
 {{- range $key, $value := .Values.agent.env }}
   {{ $key }}: {{ $value | quote }}

--- a/charts/cofide-agent/templates/configmap.yaml
+++ b/charts/cofide-agent/templates/configmap.yaml
@@ -9,7 +9,7 @@ data:
   {{ $key }}: {{ $value | quote }}
 {{- end }}
 {{- end }}
---
+---
 
 {{- $existingConfigMap := lookup "v1" "ConfigMap" .Release.Namespace "cofide-agent-state" }}
 {{- if not $existingConfigMap }}

--- a/charts/cofide-agent/templates/configmap.yaml
+++ b/charts/cofide-agent/templates/configmap.yaml
@@ -1,9 +1,15 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cofide-agent
+  name: cofide-agent-config
 data:
 {{- range $key, $value := .Values.agent.env }}
   {{ $key }}: {{ $value | quote }}
 {{- end }}
 
+--
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cofide-agent-state

--- a/charts/cofide-agent/templates/configmap.yaml
+++ b/charts/cofide-agent/templates/configmap.yaml
@@ -1,5 +1,3 @@
-{{- $existingConfigMap := lookup "v1" "ConfigMap" .Release.Namespace "cofide-agent" }}
-{{- if not $existingConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,7 +5,6 @@ metadata:
 data:
 {{- range $key, $value := .Values.agent.env }}
   {{ $key }}: {{ $value | quote }}
-{{- end }}
 {{- end }}
 ---
 

--- a/charts/cofide-agent/templates/role.yaml
+++ b/charts/cofide-agent/templates/role.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: ["cofide-agent-config"]
+    resourceNames: ["cofide-agent"]
     verbs:
       - "get"
       - "list"

--- a/charts/cofide-agent/templates/role.yaml
+++ b/charts/cofide-agent/templates/role.yaml
@@ -11,6 +11,8 @@ rules:
       - "get"
       - "list"
       - "watch"
+      - "update"
+      - "patch"
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames: ["cofide-agent-state"]

--- a/charts/cofide-agent/templates/role.yaml
+++ b/charts/cofide-agent/templates/role.yaml
@@ -6,7 +6,14 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: ["cofide-agent"]
+    resourceNames: ["cofide-agent-config"]
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cofide-agent-state"]
     verbs:
       - "get"
       - "list"

--- a/charts/cofide-agent/templates/role.yaml
+++ b/charts/cofide-agent/templates/role.yaml
@@ -11,8 +11,6 @@ rules:
       - "get"
       - "list"
       - "watch"
-      - "update"
-      - "patch"
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames: ["cofide-agent-state"]


### PR DESCRIPTION
In a new version of the agent, we'll support separate ConfigMaps for the agent's config (immutable) and state (mutable).