### PR TITLE
test: release charts automatically on push to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,8 @@
 name: publish-helm-chart
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
This avoids the manual workflow dispatch.
