### PR TITLE
feat: bump Cofide Observer to v0.3.0

### DIFF
--- a/charts/cofide-observer/Chart.yaml
+++ b/charts/cofide-observer/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cofide-observer
 description: Helm chart to deploy Cofide Observer
 type: application
-version: 0.2.1
-appVersion: "v0.2.0"
+version: 0.3.0
+appVersion: "v0.3.0"
 maintainers:
   - name: Cofide
     url: https://cofide.io

--- a/charts/cofide-observer/templates/clusterrole.yaml
+++ b/charts/cofide-observer/templates/clusterrole.yaml
@@ -6,3 +6,6 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]


### PR DESCRIPTION
This brings in support for including the node UID in Workloads published
to Connect. The Helm chart has been updated to allow listing nodes in
the observer's cluster role.

https://github.com/cofide/cofide-observer/releases/tag/v0.3.0
