### PR TITLE
Agent state ConfigMap handling for chart upgrade/deletion

### DIFF
--- a/charts/cofide-agent/Chart.yaml
+++ b/charts/cofide-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-agent/templates/configmap.yaml
+++ b/charts/cofide-agent/templates/configmap.yaml
@@ -7,11 +7,15 @@ data:
   {{ $key }}: {{ $value | quote }}
 {{- end }}
 ---
-
-{{- $existingConfigMap := lookup "v1" "ConfigMap" .Release.Namespace "cofide-agent-state" }}
-{{- if not $existingConfigMap }}
+# This ConfigMap is always part of the release, so Helm can manage its lifecycle.
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cofide-agent-state
+{{- $existingState := lookup "v1" "ConfigMap" .Release.Namespace "cofide-agent-state" }}
+data:
+{{- if and $existingState $existingState.data }}
+  {{- toYaml $existingState.data | nindent 2 }}
+{{- else }}
+  {}
 {{- end }}


### PR DESCRIPTION
Ensures the cofide-agent-state ConfigMap is always declared as part of the Helm release, allowing Helm to properly manage its lifecycle during chart upgrades and deletions. Previously, it was conditionally created only if it didn't exist.