### PR TITLE
Add additional RBAC to the Observer

### DIFF
--- a/charts/cofide-observer/Chart.yaml
+++ b/charts/cofide-observer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cofide-observer
 description: Helm chart to deploy Cofide Observer
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "v0.3.0"
 maintainers:
   - name: Cofide

--- a/charts/cofide-observer/templates/clusterrole.yaml
+++ b/charts/cofide-observer/templates/clusterrole.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}
+  name: { { .Release.Name } }
 rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list"]
+    verbs: ["list", "get", "watch"]

--- a/charts/cofide-observer/templates/clusterrole.yaml
+++ b/charts/cofide-observer/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: { { .Release.Name } }
+  name: {{ .Release.Name }}
 rules:
   - apiGroups: [""]
     resources: ["pods"]


### PR DESCRIPTION
`cofide-observer` requires additional permissions to `get` and `watch` node resources.