### PR TITLE
Add missing s3UseOIDC to config and render booleans correctly

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/templates/configmap.yaml
+++ b/charts/cofide-connect/templates/configmap.yaml
@@ -9,6 +9,7 @@ data:
     insecure_server_address: {{ .Values.connect.insecureServerAddress.host }}:{{ .Values.connect.insecureServerAddress.port }}
     ads_server_address: {{ .Values.connect.adsServerAddress.host }}:{{ .Values.connect.adsServerAddress.port }}
     spiffe_endpoint_socket: {{ .Values.connect.spiffeEndpointSocket }}
+    s3_use_oidc: {{ .Values.connect.s3UseOIDC | toString }}
     aws_region: {{ .Values.connect.awsRegion }}
     iam_role_arn: {{ .Values.connect.iamRoleARN }}
     oidc_provider_audience: {{ .Values.connect.oidcProviderAudience }}
@@ -19,7 +20,7 @@ data:
     connect_trust_bundle_store_url: {{ .Values.connect.connectTrustBundleStoreURL }}
     sql_connection_string: {{ .Values.connect.sqlConnectionString }}
     sql_remote_spiffe_id: {{ .Values.connect.sqlRemoteSPIFFEID }}
-    telemetry_enabled: {{ .Values.connect.telemetryEnabled }}
+    telemetry_enabled: {{ .Values.connect.telemetryEnabled | toString }}
     authz_policy_engine: {{ .Values.connect.authzPolicyEngine }}
     initial_rbac:
       version: {{ .Values.connect.initialRBAC.version }}


### PR DESCRIPTION
Realised that in previous PR s3UseOIDC from values wasn't populated into the configmap - this is fine in the application's default case (using OIDC to access S3) but means this can't be disabled.

Also discovered that the boolean fields would render as empty string when they were false (because of Go's templating engine converting them to a string) - explicitly converting them means they render as true/false as expected.