### PR TITLE
chore: bump Cofide Agent, Connect, SPIFFE enable versions

### DIFF
--- a/charts/cofide-agent/Chart.yaml
+++ b/charts/cofide-agent/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.36.0"
+appVersion: "v0.38.0"
 
 maintainers:
   - name: Cofide

--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.36.0"
+appVersion: "v0.38.0"
 
 maintainers:
   - name: Cofide

--- a/charts/spiffe-enable/Chart.yaml
+++ b/charts/spiffe-enable/Chart.yaml
@@ -3,9 +3,9 @@ name: spiffe-enable
 description: Helm chart for the spiffe-enable admission webhook for Kubernetes
 type: application
 
-version: 0.1.5
+version: 0.1.6
 
-appVersion: "v0.4.0"
+appVersion: "v0.5.0"
 
 maintainers:
   - name: Cofide


### PR DESCRIPTION
Bumps Cofide Agent and Connect to v0.38.0
Bumps SPIFFE enable to v0.5.0
