### PR TITLE
Remove valkey dependency

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.38.0"
+appVersion: "v0.38.3"
 
 maintainers:
   - name: Cofide

--- a/charts/cofide-connect/templates/configmap.yaml
+++ b/charts/cofide-connect/templates/configmap.yaml
@@ -17,7 +17,6 @@ data:
     trust_bundle_store_bucket: {{ .Values.connect.trustBundleStoreBucket }}
     connect_psat_audience: {{ .Values.connect.connectPSATAudience }}
     connect_trust_domain: {{ .Values.connect.trustDomain }}
-    valkey_address: {{ .Values.connect.valkeyAddress }}
     connect_trust_bundle_store_url: {{ .Values.connect.connectTrustBundleStoreURL }}
     sql_connection_string: {{ .Values.connect.sqlConnectionString }}
     sql_remote_spiffe_id: {{ .Values.connect.sqlRemoteSPIFFEID }}

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -81,10 +81,6 @@
           "type": "string",
           "description": "The trust domain of the Connect trust zone."
         },
-        "valkeyAddress": {
-          "type": "string",
-          "description": "Address for the Valkey node."
-        },
         "connectTrustBundleStoreURL": {
           "type": "string",
           "description": "URL for the Connect trust bundle store."
@@ -231,7 +227,6 @@
         "trustBundleStoreBucket",
         "connectPSATAudience",
         "trustDomain",
-        "valkeyAddress",
         "connectTrustBundleStoreURL",
         "sqlConnectionString",
         "sqlRemoteSPIFFEID",

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -47,8 +47,6 @@ connect:
   connectPSATAudience: ""
   # Trust domain of in-cluster SPIRE server.
   trustDomain: ""
-  # Address of valkey instance (expected to be in-cluster as no auth is used).
-  valkeyAddress: valkey.connect.svc.cluster.local:6379
   # URL trust bundle store is available at.
   connectTrustBundleStoreURL: ""
   # SQL connection string for SQLite or Postgres database. SQLite should only be used for non-production workloads.


### PR DESCRIPTION
> ~~Requires Connect release including https://github.com/cofide/cofide-connect/pull/1522 to be merged first, then the appVersion here can be bumped too~~ done

Part of https://github.com/cofide/cofide-connect/issues/1250

Removes valkey dependency, as the database is now used for agent token storage in upcoming release of Connect.