### PR TITLE
Allow configuring jwksUri

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -150,7 +150,7 @@ data:
                                 {{- include "cofide-connect.envoy.auth.audiences" . | nindent 32 }}
                               remote_jwks:
                                 http_uri:
-                                  uri: {{ .Values.envoy.auth.issuer }}/.well-known/jwks.json
+                                  uri: {{ .Values.envoy.auth.jwksUri }}
                                   cluster: jwks_cluster
                                   timeout: 30s
                               claim_to_headers:
@@ -325,17 +325,23 @@ data:
                   - endpoint:
                       address:
                         socket_address:
-                          address: {{ (urlParse .Values.envoy.auth.issuer).host }}
+                          address: {{ (urlParse .Values.envoy.auth.jwksUri).host }}
+                          {{- if eq (urlParse .Values.envoy.auth.jwksUri).scheme "https" }}
                           port_value: 443
+                          {{- else }}
+                          port_value: 80
+                          {{- end }}
+          {{- if eq (urlParse .Values.envoy.auth.jwksUri).scheme "https" }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
               '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              sni: {{ (urlParse .Values.envoy.auth.issuer).host }}
+              sni: {{ (urlParse .Values.envoy.auth.jwksUri).host }}
               common_tls_context:
                 tls_params:
                   tls_minimum_protocol_version: TLSv1_3
                   tls_maximum_protocol_version: TLSv1_3
+          {{- end }}
     admin:
       access_log_path: /dev/stdout
       address:

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -106,6 +106,8 @@ envoy:
   auth:
     # Issuer of the IdP in use.
     issuer: ""
+    # JWKS URI of the IdP in use. Only http and https schemes are supported. Setting custom port is not supported.
+    jwksUri: ""
     # Name of secret in the same namespace containing the TLS private key and cert to be used with the domain Connect is exposed on.
     # This certificate must be valid for connect.{{ .Values.connect.urlBase }}, connect-agent.{{ .Values.connect.urlBase }} and xds.{{ .Values.connect.urlBase }}.
     tlsSecretName: ""


### PR DESCRIPTION
This has to be independent of the issuer (which could be not even a URI in case of JWTs other than ID tokens).

Additionally, support both https and http (for simple, local deployments) schemes.

Value name (jwksUri) casing follows the casing from Istio.