### PR TITLE
Consolidate config for datastore into single block

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.38.6"
+appVersion: "v0.38.8"
 
 maintainers:
   - name: Cofide

--- a/charts/cofide-connect/templates/configmap.yaml
+++ b/charts/cofide-connect/templates/configmap.yaml
@@ -34,6 +34,12 @@ data:
         {{- end }}
       {{- end }}
     datastore:
+      {{- with .Values.connect.datastore.sqlConnectionString }}
+      sql_connection_string:
+        enabled: {{ .enabled }}
+        connection_string: {{ .connectionString | quote }}
+        remote_spiffe_id: {{ .remoteSPIFFEID | quote }}
+      {{- end }}
       {{- with .Values.connect.datastore.cloudSQL }}
       cloudsql:
         enabled: {{ .enabled }}
@@ -49,8 +55,6 @@ data:
     connect_psat_audience: {{ .Values.connect.connectPSATAudience }}
     connect_trust_domain: {{ .Values.connect.trustDomain }}
     connect_trust_bundle_store_url: {{ .Values.connect.connectTrustBundleStoreURL }}
-    sql_connection_string: {{ .Values.connect.sqlConnectionString }}
-    sql_remote_spiffe_id: {{ .Values.connect.sqlRemoteSPIFFEID }}
     telemetry_enabled: {{ .Values.connect.telemetryEnabled | toString }}
     authz_policy_engine: {{ .Values.connect.authzPolicyEngine }}
     initial_rbac:

--- a/charts/cofide-connect/templates/deployment.yaml
+++ b/charts/cofide-connect/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
               mountPath: /spiffe-workload-api
             - name: connect-config
               mountPath: /app/config
-            {{- if (hasPrefix "sqlite" .Values.connect.sqlConnectionString ) }}
+            {{- if (hasPrefix "sqlite" .Values.connect.datastore.sqlConnectionString.connectionString ) }}
             - name: sqlite-data
               mountPath: "/app/data"
             {{- end }}
@@ -146,7 +146,7 @@ spec:
         - name: envoy-tls
           secret:
             secretName: {{ .Values.envoy.auth.tlsSecretName }}
-        {{- if (hasPrefix "sqlite" .Values.connect.sqlConnectionString ) }}
+        {{- if (hasPrefix "sqlite" .Values.connect.datastore.sqlConnectionString.connectionString ) }}
         - name: sqlite-data
           hostPath:
             path: /app/data

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -143,14 +143,33 @@
             }
           ]
         },
-	"datastore": {
-	  "type": "object",
-	  "description": "Configuration of the datastore used by Connect",
-	  "properties": {
-	    "cloudSQL": {
-	      "type": "object",
-	      "description": "Google CloudSQL configuration",
-	      "properties": {
+        "datastore": {
+          "type": "object",
+          "description": "Configuration of the datastore used by Connect",
+          "properties": {
+            "sqlConnectionString": {
+              "type": "object",
+              "description": "SQL connection string configuration",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "True to enable SQL connection string datastore connection"
+                },
+                "connectionString": {
+                  "type": "string",
+                  "description": "Connection string for the SQL database."
+                },
+                "remoteSPIFFEID": {
+                  "type": "string",
+                  "description": "SPIFFE ID for the remote SQL server."
+                }
+              },
+              "required": ["enabled", "connectionString", "remoteSPIFFEID"]
+            },
+            "cloudSQL": {
+              "type": "object",
+              "description": "Google CloudSQL configuration",
+              "properties": {
                 "enabled": {
                   "type": "boolean",
                   "description": "True to enable Google CloudSQL as the datastore"
@@ -164,7 +183,7 @@
                   "description": "Name of the Connect database",
                   "minLength": 1
                 },
-	        "oidc": {
+                "oidc": {
                   "type": "object",
                   "description": "Configuration to use OIDC to access Google CloudSQL",
                   "properties": {
@@ -180,12 +199,15 @@
                       "type": "string",
                       "description": "Name of service account with access privileges to the Connect database"
                     }
-                  }
-	        }
-	      }
-	    }
-          }
-	},
+                  },
+                  "required": ["workloadIdentityProvider", "audience", "serviceAccountName"]
+                }
+              },
+              "required": ["enabled", "instance", "databaseName", "oidc"]
+            }
+          },
+          "required": ["sqlConnectionString", "cloudSQL"]
+        },
         "connectPSATAudience": {
           "type": "string",
           "description": "Audience value to expect when using PSATs for Cofide SPIRE."
@@ -197,14 +219,6 @@
         "connectTrustBundleStoreURL": {
           "type": "string",
           "description": "URL for the Connect trust bundle store."
-        },
-        "sqlConnectionString": {
-          "type": "string",
-          "description": "Connection string for the SQL database."
-        },
-        "sqlRemoteSPIFFEID": {
-          "type": "string",
-          "description": "SPIFFE ID for the remote SQL server."
         },
         "telemetryEnabled": {
           "type": "boolean",
@@ -334,11 +348,10 @@
         "adsServerAddress",
         "spiffeEndpointSocket",
         "trustBundleStoreBackend",
+        "datastore",
         "connectPSATAudience",
         "trustDomain",
         "connectTrustBundleStoreURL",
-        "sqlConnectionString",
-        "sqlRemoteSPIFFEID",
         "telemetryEnabled",
         "authzPolicyEngine",
         "initialRBAC",

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -66,6 +66,14 @@ connect:
         audience: ""
   # Configuration of the datastore used by Connect
   datastore:
+    sqlConnectionString:
+      # True to enable using a SQL connection string to connect to the datastore
+      enabled: true
+      # SQL connection string for SQLite or Postgres database. SQLite should only be used for non-production workloads.
+      # A username/password can be included in this connection string to connect to databases that do not support mTLS.
+      connectionString: ""
+      # For databases that support mTLS this is the SPIFFE ID that Connect will expect to be presented
+      remoteSPIFFEID: ""
     cloudSQL:
       # True to enable Google CloudSQL as the datastore
       enabled: false
@@ -89,11 +97,6 @@ connect:
   trustDomain: ""
   # URL trust bundle store is available at.
   connectTrustBundleStoreURL: ""
-  # SQL connection string for SQLite or Postgres database. SQLite should only be used for non-production workloads.
-  # A username/password can be included in this connection string to connect to databases that do not support mTLS.
-  sqlConnectionString: ""
-  # For databases that support mTLS this is the SPIFFE ID that Connect will expect to be presented.
-  sqlRemoteSPIFFEID: ""
   # Whether to enable the open telemetry metrics server - exposed on port 4317.
   telemetryEnabled: false
   # Authz policy engine to use. Valid values: opa, none. "none" disables authz and is not suitable for production.


### PR DESCRIPTION
> Depends on https://github.com/cofide/cofide-connect/pull/1553 to release a version of Connect that supports this new config.

Part of https://github.com/cofide/helm-charts/issues/75

Consolidates the config for the datastore into a single block to simplify it as more datastore support is added.