### PR TITLE
Support CloudSQL instances with PSC

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.1
+version: 0.10.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/templates/configmap.yaml
+++ b/charts/cofide-connect/templates/configmap.yaml
@@ -45,6 +45,7 @@ data:
         enabled: {{ .enabled }}
         instance: {{ .instance | quote }}
         database_name: {{ .databaseName | quote }}
+        psc_enabled: {{ .pscEnabled }}
         {{- with .oidc }}
         oidc:
           workload_identity_provider: {{ .workloadIdentityProvider | quote }}

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -183,6 +183,10 @@
                   "description": "Name of the Connect database",
                   "minLength": 1
                 },
+                "pscEnabled": {
+                  "type": "boolean",
+                  "description": "Whether to use Private Service Connect to connect to the CloudSQL instance"
+                },
                 "oidc": {
                   "type": "object",
                   "description": "Configuration to use OIDC to access Google CloudSQL",
@@ -203,7 +207,7 @@
                   "required": ["workloadIdentityProvider", "audience", "serviceAccountName"]
                 }
               },
-              "required": ["enabled", "instance", "databaseName", "oidc"]
+              "required": ["enabled", "instance", "databaseName", "pscEnabled", "oidc"]
             }
           },
           "required": ["sqlConnectionString", "cloudSQL"]

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -82,6 +82,8 @@ connect:
       instance: ""
       # Name of the Connect database
       databaseName: "connect-db"
+      # Whether to use Private Service Connect to connect to the database instance
+      pscEnabled: false
       # Configuration to use OIDC to access Google CloudSQL, exchanging server's SVID for a SA impersonation token 
       oidc:
         # Fully qualified identifier of GCP workload identity provider to use when obtaining credentials through OIDC.


### PR DESCRIPTION
Companion to https://github.com/cofide/cofide-connect/pull/1581 to pass through the config for declaring that the configuration to connect to the CloudSQL instance should use Private Service Connect.