### PR TITLE
Add missing permission for cofide-agent to manage TrustZoneServer CRs

### DIFF
--- a/charts/cofide-agent/Chart.yaml
+++ b/charts/cofide-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4
+version: 0.4.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-agent/templates/cluster-role.yaml
+++ b/charts/cofide-agent/templates/cluster-role.yaml
@@ -25,3 +25,13 @@ rules:
     - federatedservices/finalizers
     - federatedservices/status
     verbs: ["*"]
+  {{- if eq (.Values.agent.env.MANAGEMENT_ZONE | toString) "true" }}
+  - apiGroups:
+      - tzaas.cofide.io
+    resources:
+      - trustzoneservers
+    verbs:
+      - get
+      - create
+      - update
+  {{- end }}


### PR DESCRIPTION
When running in a management trust zone cluster the cofide-agent needs permissions to manage TrustZoneServer CRs.