### PR TITLE
test: try to prevent caching when downloading the SPIRE index

### DIFF
--- a/.github/actions/aggregate-indexes/action.yml
+++ b/.github/actions/aggregate-indexes/action.yml
@@ -22,7 +22,9 @@ runs:
         mkdir -p temp-indexes
 
         # Download index from Cofide SPIRE Helm charts
-        curl --fail -L -o temp-indexes/spiffe-helm-charts-hardened-index.yaml \
+        curl --fail -L \
+          -H 'Cache-Control: no-cache' \
+          -o temp-indexes/spiffe-helm-charts-hardened-index.yaml \
           https://cofide.github.io/spiffe-helm-charts-hardened/index.yaml
 
     - name: Install ruamel.yaml


### PR DESCRIPTION
When aggregating the Helm chart indexes (Cofide SPIRE and this repo), we
need to have the latest version of the remote index, to avoid missing a
version update. Try using the no-cache header to prevent caching.
