### PR TITLE
fix: add a retry policy and async fetch for Connect's remote JWKS

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.2
+version: 0.11.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -153,6 +153,13 @@ data:
                                   uri: {{ .Values.envoy.auth.jwksUri }}
                                   cluster: jwks_cluster
                                   timeout: 30s
+                                # Use the default backoff strategy with 5 retries.
+                                retry_policy:
+                                  num_retries: 5
+                                  retry_on: 5xx,reset
+                                # Fetch JWKS in a background thread. Wait for the fetch to complete before starting the listener.
+                                async_fetch:
+                                  fast_listener: false
                               claim_to_headers:
                                 - header_name: x-jwt-claim-sub
                                   claim_name: sub


### PR DESCRIPTION
We sometimes see API requests to the TLS API of Connect fail with:

  Jwks remote fetch is failed

This has been traced to Envoy's JWT authenticator. Previously we
configured it without retry policy, leaving it vulnerable to
intermittent failures.

We also used on-demand JWKS fetch, rather than a background thread
(async fetch). This required each thread to individually cache the JWKS,
increasing the likeliness of being affected by IdP flakiness.

This change addresses both of these issues.

Fixes: cofide/cofide-connect#223

Docs: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#extensions-filters-http-jwt-authn-v3-remotejwks
