### PR TITLE
chore: Uprev spiffe-enable image

### DIFF
--- a/charts/spiffe-enable/Chart.yaml
+++ b/charts/spiffe-enable/Chart.yaml
@@ -3,9 +3,9 @@ name: spiffe-enable
 description: Helm chart for the spiffe-enable admission webhook for Kubernetes
 type: application
 
-version: 0.1.7
+version: 0.1.8
 
-appVersion: "v0.5.0"
+appVersion: "v0.5.2"
 
 maintainers:
   - name: Cofide


### PR DESCRIPTION
* Now uses `v0.5.2`