### PR TITLE
fix: reload Connect API and UI TLS certificate when rotated

### DIFF
--- a/charts/cofide-connect-ui/Chart.yaml
+++ b/charts/cofide-connect-ui/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect-ui/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect-ui/templates/configmap-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "cofide-connect-ui.labels" . | nindent 4 }}
 data:
+  # envoy.yaml is the main Envoy configuration file.
   envoy.yaml: |
     node:
       id: connect-ui-envoy-proxy
@@ -34,11 +35,11 @@ data:
                   common_tls_context:
                     alpn_protocols:
                       - h2
-                    tls_certificates:
-                      - certificate_chain:
-                          filename: /etc/envoy/tls/tls.crt
-                        private_key:
-                          filename: /etc/envoy/tls/tls.key
+                    tls_certificate_sds_secret_configs:
+                      - name: connect_ui_tls_cert
+                        sds_config:
+                          path_config_source:
+                            path: /etc/envoy/envoy-sds.yaml
               filters:
                 - name: envoy.filters.network.http_connection_manager
                   typed_config:
@@ -102,3 +103,18 @@ data:
         socket_address:
           address: 127.0.0.1
           port_value: 9901
+
+  # envoy-sds.yaml is a Secret Discovery Service (SDS) configuration file.
+  # This is used as an SDS dynamic configuration source, supporting automatic
+  # certificate rotation by ensuring that a filesystem watch is used for the
+  # certificate and key. See example 3 in
+  # https://www.envoyproxy.io/docs/envoy/latest/configuration/security/secret#key-rotation
+  envoy-sds.yaml: |
+    resources:
+      - "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+        name: connect_ui_tls_cert
+        tls_certificate:
+          certificate_chain:
+            filename: /etc/envoy/tls/tls.crt
+          private_key:
+            filename: /etc/envoy/tls/tls.key

--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.4
+version: 0.11.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -3,6 +3,7 @@ kind: ConfigMap
 metadata:
   name: connect-api-envoy-config
 data:
+  # envoy.yaml is the main Envoy configuration file.
   envoy.yaml: |
     node:
       id: connect-api-envoy-proxy
@@ -96,11 +97,11 @@ data:
                   common_tls_context:
                     alpn_protocols:
                       - h2
-                    tls_certificates:
-                      - certificate_chain:
-                          filename: /etc/envoy/tls/tls.crt
-                        private_key:
-                          filename: /etc/envoy/tls/tls.key
+                    tls_certificate_sds_secret_configs:
+                      - name: connect_api_tls_cert
+                        sds_config:
+                          path_config_source:
+                            path: /etc/envoy/envoy-sds.yaml
               filters:
                 - name: envoy.filters.network.http_connection_manager
                   typed_config:
@@ -366,3 +367,18 @@ data:
         socket_address:
           address: 127.0.0.1
           port_value: 9901
+
+  # envoy-sds.yaml is a Secret Discovery Service (SDS) configuration file.
+  # This is used as an SDS dynamic configuration source, supporting automatic
+  # certificate rotation by ensuring that a filesystem watch is used for the
+  # certificate and key. See example 3 in
+  # https://www.envoyproxy.io/docs/envoy/latest/configuration/security/secret#key-rotation
+  envoy-sds.yaml: |
+    resources:
+      - "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+        name: connect_api_tls_cert
+        tls_certificate:
+          certificate_chain:
+            filename: /etc/envoy/tls/tls.crt
+          private_key:
+            filename: /etc/envoy/tls/tls.key


### PR DESCRIPTION
By using SDS to define the certificate secrets, Envoy will watch the
directory for changes, and reload when certificates are rotated.

Note that the SDS resources cannot be in static_resources, which is why
we use a separate file as a dynamic SDS configuration source. See
example 3 in [1].

[1] https://www.envoyproxy.io/docs/envoy/latest/configuration/security/secret#key-rotation

Fixes: https://github.com/cofide/cofide-connect/issues/1383
