### PR TITLE
WIP: Support cluster names in cofide svids

### DIFF
--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -230,7 +230,7 @@ data:
                           - san_type: URI
                             matcher:
                               safe_regex:
-                                regex: spiffe://[^/]*/ns/cofide/sa/cofide-agent
+                                regex: spiffe://[^/]+/cluster/[\w-]+/ns/cofide/sa/cofide-agent
                           - san_type: URI
                             matcher:
                               safe_regex:
@@ -238,7 +238,7 @@ data:
                           - san_type: URI
                             matcher:
                               safe_regex:
-                                regex: spiffe://[^/]*/ns/cofide/sa/cofide-observer
+                                regex: spiffe://[^/]+/cluster/[\w-]+/ns/cofide/sa/cofide-observer
                       validation_context_sds_secret_config:
                         name: ALL
                         sds_config:


### PR DESCRIPTION
Part of https://github.com/cofide/cofide/issues/175

Cluster names in cofide svids (specifically the observer) are needed to support multi-cluster trust zones.

Superseded by https://github.com/cofide/helm-charts/pull/97 - will close once merged