### PR TITLE
TZaaS helm charts

### DIFF
--- a/charts/cofide-trust-zone-operator/.helmignore
+++ b/charts/cofide-trust-zone-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cofide-trust-zone-operator/Chart.yaml
+++ b/charts/cofide-trust-zone-operator/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: cofide-trust-zone-operator
+description: Helm chart to deploy the Cofide Trust Zone Operator to a Kubernetes cluster
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+
+maintainers:
+  - name: Cofide
+    url: https://cofide.io

--- a/charts/cofide-trust-zone-operator/ci/required-values.yaml
+++ b/charts/cofide-trust-zone-operator/ci/required-values.yaml
@@ -7,3 +7,5 @@ connect:
 gateway:
   # Base domain for Gateway API TLSRoutes. Required.
   baseDomain: example.org
+  # Name of the GatewayClass to use. Required.
+  className: eg

--- a/charts/cofide-trust-zone-operator/ci/required-values.yaml
+++ b/charts/cofide-trust-zone-operator/ci/required-values.yaml
@@ -1,0 +1,9 @@
+connect:
+  # URL of the Connect instance. Required.
+  url: api.connect.example.org:4321
+  # Trust domain of the Connect instance. Required.
+  trustDomain: connect.example.org
+
+gateway:
+  # Base domain for Gateway API TLSRoutes. Required.
+  baseDomain: example.org

--- a/charts/cofide-trust-zone-operator/templates/NOTES.txt
+++ b/charts/cofide-trust-zone-operator/templates/NOTES.txt
@@ -1,0 +1,19 @@
+The Cofide Trust Zone Operator has been deployed.
+
+Verify the operator is running:
+
+  kubectl get deployment {{ include "cofide-trust-zone-operator.fullname" . }} -n {{ .Release.Namespace }}
+
+NOTE: The operator requires the CRDs from the cofide-tzaas-crds chart to be installed separately before use.
+{{- if or (not .Values.connect.url) (not .Values.connect.trustDomain) }}
+
+WARNING: Connect integration is not configured. Set connect.url and connect.trustDomain to enable it.
+{{- end }}
+{{- if not .Values.gateway.baseDomain }}
+
+WARNING: gateway.baseDomain is not set. This is required for Gateway API TLSRoute configuration.
+{{- end }}
+
+To list managed TrustZoneServer resources:
+
+  kubectl get trustzoneservers -A

--- a/charts/cofide-trust-zone-operator/templates/_helpers.tpl
+++ b/charts/cofide-trust-zone-operator/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cofide-trust-zone-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cofide-trust-zone-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cofide-trust-zone-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cofide-trust-zone-operator.labels" -}}
+helm.sh/chart: {{ include "cofide-trust-zone-operator.chart" . }}
+{{ include "cofide-trust-zone-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cofide-trust-zone-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cofide-trust-zone-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cofide-trust-zone-operator.serviceAccountName" -}}
+{{- $default := (include "cofide-trust-zone-operator.fullname" .) }}
+{{- with .Values.serviceAccount }}
+{{- if .create }}
+{{- default $default .name }}
+{{- else }}
+{{- default "default" .name }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cofide-trust-zone-operator/templates/deployment.yaml
+++ b/charts/cofide-trust-zone-operator/templates/deployment.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}
+  labels:
+    control-plane: trust-zone-operator
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.trustZoneOperator.replicas }}
+  selector:
+    matchLabels:
+      control-plane: trust-zone-operator
+    {{- include "cofide-trust-zone-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        control-plane: trust-zone-operator
+      {{- include "cofide-trust-zone-operator.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      containers:
+      {{- $args := concat .Values.trustZoneOperator.manager.args (list (printf "--health-probe-bind-address=:%d" (int .Values.healthProbe.port))) }}
+      {{- $args = append $args (printf "--gateway-namespace=%s" .Values.gateway.namespace) }}
+      {{- if .Values.gateway.baseDomain }}
+      {{- $args = append $args (printf "--gateway-base-domain=%s" .Values.gateway.baseDomain) }}
+      {{- end }}
+      {{- if .Values.connect.url }}
+      {{- $args = append $args (printf "--connect-url=%s" .Values.connect.url) }}
+      {{- end }}
+      {{- if .Values.connect.trustDomain }}
+      {{- $args = append $args (printf "--connect-trust-domain=%s" .Values.connect.trustDomain) }}
+      {{- end }}
+      {{- if .Values.connect.cluster.clusterId }}
+      {{- $args = append $args (printf "--cluster-id=%s" .Values.connect.cluster.clusterId) }}
+      {{- end }}
+      {{- if .Values.leaderElection.enabled }}
+      {{- $args = append $args "--leader-elect" }}
+      {{- end }}
+      {{- if .Values.metrics.enabled }}
+      {{- $args = append $args (printf "--metrics-bind-address=:%d" (int (index .Values.metrics.service.ports 0).targetPort)) }}
+      {{- $args = append $args (printf "--metrics-secure=%t" .Values.metrics.tls.enabled) }}
+      {{- if and .Values.metrics.tls.enabled (not .Values.metrics.tls.certSecretName) }}
+      {{- required "metrics.tls.certSecretName must be set when metrics.tls.enabled=true (or set metrics.tls.enabled=false for local development)" .Values.metrics.tls.certSecretName }}
+      {{- end }}
+      {{- if and .Values.metrics.tls.enabled .Values.metrics.tls.certSecretName }}
+      {{- $args = append $args "--metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs" }}
+      {{- end }}
+      {{- end }}
+      - args: {{- toYaml $args | nindent 8 }}
+        command:
+        - /manager
+        env:
+        - name: SPIFFE_ENDPOINT_SOCKET
+          value: {{ quote .Values.trustZoneOperator.manager.env.spiffeEndpointSocket }}
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ quote .Values.kubernetesClusterDomain }}
+        image: {{ .Values.trustZoneOperator.manager.image.registry }}/{{ .Values.trustZoneOperator.manager.image.repository }}:{{ .Values.trustZoneOperator.manager.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.trustZoneOperator.manager.imagePullPolicy }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.healthProbe.port }}
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: {{ .Values.healthProbe.port }}
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{- toYaml .Values.trustZoneOperator.manager.resources | nindent 10 }}
+        securityContext: {{- toYaml .Values.trustZoneOperator.manager.containerSecurityContext | nindent 10 }}
+        volumeMounts:
+        - mountPath: /tmp/helm
+          name: helm
+        - mountPath: /spiffe-workload-api
+          name: spiffe-workload-api
+          readOnly: true
+        {{- if and .Values.metrics.enabled .Values.metrics.tls.enabled .Values.metrics.tls.certSecretName }}
+        - mountPath: /tmp/k8s-metrics-server/metrics-certs
+          name: metrics-certs
+          readOnly: true
+        {{- end }}
+      nodeSelector: {{- toYaml .Values.trustZoneOperator.nodeSelector | nindent 8 }}
+      securityContext: {{- toYaml .Values.trustZoneOperator.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "cofide-trust-zone-operator.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 10
+      tolerations: {{- toYaml .Values.trustZoneOperator.tolerations | nindent 8 }}
+      topologySpreadConstraints: {{- toYaml .Values.trustZoneOperator.topologySpreadConstraints | nindent 8 }}
+      volumes:
+      - emptyDir: {}
+        name: helm
+      - csi:
+          driver: csi.spiffe.io
+          readOnly: true
+        name: spiffe-workload-api
+      {{- if and .Values.metrics.enabled .Values.metrics.tls.enabled .Values.metrics.tls.certSecretName }}
+      - name: metrics-certs
+        secret:
+          secretName: {{ .Values.metrics.tls.certSecretName }}
+          optional: false
+          items:
+            - key: tls.crt
+              path: tls.crt
+            - key: tls.key
+              path: tls.key
+      {{- end }}

--- a/charts/cofide-trust-zone-operator/templates/deployment.yaml
+++ b/charts/cofide-trust-zone-operator/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       {{- if .Values.gateway.baseDomain }}
       {{- $args = append $args (printf "--gateway-base-domain=%s" .Values.gateway.baseDomain) }}
       {{- end }}
+      {{- $args = append $args (printf "--gateway-name=%s" .Values.gateway.name) }}
       {{- if .Values.connect.url }}
       {{- $args = append $args (printf "--connect-url=%s" .Values.connect.url) }}
       {{- end }}

--- a/charts/cofide-trust-zone-operator/templates/deployment.yaml
+++ b/charts/cofide-trust-zone-operator/templates/deployment.yaml
@@ -38,9 +38,13 @@ spec:
       {{- if .Values.connect.trustDomain }}
       {{- $args = append $args (printf "--connect-trust-domain=%s" .Values.connect.trustDomain) }}
       {{- end }}
+      {{- if .Values.connect.bundleUrl }}
+      {{- $args = append $args (printf "--connect-bundle-url=%s" .Values.connect.bundleUrl) }}
+      {{- end }}
       {{- if .Values.connect.cluster.clusterId }}
       {{- $args = append $args (printf "--cluster-id=%s" .Values.connect.cluster.clusterId) }}
       {{- end }}
+      {{- $args = append $args (printf "--helm-release-namespace=%s" (.Values.operator.namespace | default .Release.Namespace)) }}
       {{- if .Values.leaderElection.enabled }}
       {{- $args = append $args "--leader-elect" }}
       {{- end }}
@@ -62,7 +66,7 @@ spec:
           value: {{ quote .Values.trustZoneOperator.manager.env.spiffeEndpointSocket }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
-        image: {{ .Values.trustZoneOperator.manager.image.registry }}/{{ .Values.trustZoneOperator.manager.image.repository }}:{{ .Values.trustZoneOperator.manager.image.tag | default .Chart.AppVersion }}
+        image: {{ if .Values.trustZoneOperator.manager.image.registry }}{{ .Values.trustZoneOperator.manager.image.registry }}/{{ end }}{{ .Values.trustZoneOperator.manager.image.repository }}:{{ .Values.trustZoneOperator.manager.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.trustZoneOperator.manager.imagePullPolicy }}
         livenessProbe:
           httpGet:

--- a/charts/cofide-trust-zone-operator/templates/envoy-proxy.yaml
+++ b/charts/cofide-trust-zone-operator/templates/envoy-proxy.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.gateway.create .Values.gateway.envoyProxy.name }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: {{ .Values.gateway.envoyProxy.name }}
+  namespace: {{ .Values.gateway.namespace }}
+  labels:
+    {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        type: {{ .Values.gateway.envoyProxy.serviceType }}
+{{- end }}

--- a/charts/cofide-trust-zone-operator/templates/gateway.yaml
+++ b/charts/cofide-trust-zone-operator/templates/gateway.yaml
@@ -8,6 +8,13 @@ metadata:
     {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
 spec:
   gatewayClassName: {{ .Values.gateway.className }}
+  {{- if .Values.gateway.envoyProxy.name }}
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: {{ .Values.gateway.envoyProxy.name }}
+  {{- end }}
   listeners:
     - name: tls-passthrough
       protocol: TLS

--- a/charts/cofide-trust-zone-operator/templates/gateway.yaml
+++ b/charts/cofide-trust-zone-operator/templates/gateway.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.gateway.name }}
+  namespace: {{ .Values.gateway.namespace }}
+  labels:
+    {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.gateway.className }}
+  listeners:
+    - name: tls-passthrough
+      protocol: TLS
+      port: 443
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All
+{{- end }}

--- a/charts/cofide-trust-zone-operator/templates/leader-election-rbac.yaml
+++ b/charts/cofide-trust-zone-operator/templates/leader-election-rbac.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.leaderElection.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-leader-election-role
+  labels:
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-leader-election-rolebinding
+  labels:
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "cofide-trust-zone-operator.fullname" . }}-leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "cofide-trust-zone-operator.serviceAccountName" . }}'
+  namespace: '{{ .Release.Namespace }}'
+{{- end }}

--- a/charts/cofide-trust-zone-operator/templates/manager-rbac.yaml
+++ b/charts/cofide-trust-zone-operator/templates/manager-rbac.yaml
@@ -5,106 +5,36 @@ metadata:
   labels:
   {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - events
-  - namespaces
-  - pods
-  - secrets
-  - serviceaccounts
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  - validatingwebhookconfigurations
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - gateway.networking.k8s.io
-  resources:
-  - referencegrants
-  - tlsroutes
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - clusterroles
-  - rolebindings
-  - roles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - tzaas.connect.cofide.io
-  resources:
-  - trustzoneservers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - tzaas.connect.cofide.io
-  resources:
-  - trustzoneservers/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - tzaas.connect.cofide.io
-  resources:
-  - trustzoneservers/status
-  verbs:
-  - get
-  - patch
-  - update
+- apiGroups: [""]
+  resources: [configmaps, secrets, serviceaccounts, services]
+  verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [""]
+  resources: [namespaces]
+  verbs: [create, delete, get, list, watch]
+- apiGroups: [""]
+  resources: [pods]
+  verbs: [get, list, watch]
+- apiGroups: [""]
+  resources: [events]
+  verbs: [create, patch]
+- apiGroups: [apps]
+  resources: [deployments, statefulsets]
+  verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [gateway.networking.k8s.io]
+  resources: [referencegrants, tlsroutes]
+  verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [rbac.authorization.k8s.io]
+  resources: [rolebindings, roles]
+  verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [tzaas.connect.cofide.io]
+  resources: [trustzoneservers]
+  verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [tzaas.connect.cofide.io]
+  resources: [trustzoneservers/finalizers]
+  verbs: [update]
+- apiGroups: [tzaas.connect.cofide.io]
+  resources: [trustzoneservers/status]
+  verbs: [get, patch, update]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/cofide-trust-zone-operator/templates/manager-rbac.yaml
+++ b/charts/cofide-trust-zone-operator/templates/manager-rbac.yaml
@@ -1,0 +1,122 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-manager-role
+  labels:
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  - namespaces
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencegrants
+  - tlsroutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - tzaas.connect.cofide.io
+  resources:
+  - trustzoneservers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - tzaas.connect.cofide.io
+  resources:
+  - trustzoneservers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - tzaas.connect.cofide.io
+  resources:
+  - trustzoneservers/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-manager-rolebinding
+  labels:
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "cofide-trust-zone-operator.fullname" . }}-manager-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "cofide-trust-zone-operator.serviceAccountName" . }}'
+  namespace: '{{ .Release.Namespace }}'

--- a/charts/cofide-trust-zone-operator/templates/metrics-auth-rbac.yaml
+++ b/charts/cofide-trust-zone-operator/templates/metrics-auth-rbac.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-metrics-auth-role
+  labels:
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-metrics-auth-rolebinding
+  labels:
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "cofide-trust-zone-operator.fullname" . }}-metrics-auth-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "cofide-trust-zone-operator.serviceAccountName" . }}'
+  namespace: '{{ .Release.Namespace }}'
+{{- end }}

--- a/charts/cofide-trust-zone-operator/templates/metrics-certificate.yaml
+++ b/charts/cofide-trust-zone-operator/templates/metrics-certificate.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.metrics.enabled .Values.metrics.tls.enabled .Values.metrics.tls.certManager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-metrics-cert
+  labels:
+    {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+spec:
+  secretName: {{ required "metrics.tls.certSecretName must be set when metrics.certManager.enabled=true" .Values.metrics.tls.certSecretName }}
+  dnsNames:
+    - {{ include "cofide-trust-zone-operator.fullname" . }}-metrics.{{ .Release.Namespace }}.svc
+    - {{ include "cofide-trust-zone-operator.fullname" . }}-metrics.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesClusterDomain }}
+  issuerRef:
+    name: {{ required "metrics.certManager.issuerName must be set when metrics.certManager.enabled=true" .Values.metrics.tls.certManager.issuerName }}
+    kind: {{ .Values.metrics.tls.certManager.issuerKind }}
+{{- end }}

--- a/charts/cofide-trust-zone-operator/templates/metrics-reader-rbac.yaml
+++ b/charts/cofide-trust-zone-operator/templates/metrics-reader-rbac.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-metrics-reader-role
+  labels:
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+{{- end }}

--- a/charts/cofide-trust-zone-operator/templates/metrics-service.yaml
+++ b/charts/cofide-trust-zone-operator/templates/metrics-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-metrics
+  labels:
+    control-plane: trust-zone-operator
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  selector:
+    control-plane: trust-zone-operator
+    {{- include "cofide-trust-zone-operator.selectorLabels" . | nindent 4 }}
+  ports:
+  {{- range .Values.metrics.service.ports }}
+  - name: {{ if $.Values.metrics.tls.enabled }}https{{ else }}http{{ end }}
+    port: {{ .port }}
+    protocol: {{ .protocol }}
+    targetPort: {{ .targetPort }}
+  {{- end }}
+{{- end }}

--- a/charts/cofide-trust-zone-operator/templates/serviceaccount.yaml
+++ b/charts/cofide-trust-zone-operator/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cofide-trust-zone-operator.serviceAccountName" . }}
+  labels:
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/cofide-trust-zone-operator/templates/trustzoneserver-admin-rbac.yaml
+++ b/charts/cofide-trust-zone-operator/templates/trustzoneserver-admin-rbac.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.rbac.createAggregateRoles }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-trustzoneserver-admin-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - tzaas.connect.cofide.io
+  resources:
+  - trustzoneservers
+  verbs:
+  - '*'
+- apiGroups:
+  - tzaas.connect.cofide.io
+  resources:
+  - trustzoneservers/status
+  verbs:
+  - get
+{{- end }}

--- a/charts/cofide-trust-zone-operator/templates/trustzoneserver-editor-rbac.yaml
+++ b/charts/cofide-trust-zone-operator/templates/trustzoneserver-editor-rbac.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.rbac.createAggregateRoles }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-trustzoneserver-editor-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - tzaas.connect.cofide.io
+  resources:
+  - trustzoneservers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - tzaas.connect.cofide.io
+  resources:
+  - trustzoneservers/status
+  verbs:
+  - get
+{{- end }}

--- a/charts/cofide-trust-zone-operator/templates/trustzoneserver-viewer-rbac.yaml
+++ b/charts/cofide-trust-zone-operator/templates/trustzoneserver-viewer-rbac.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbac.createAggregateRoles }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-trustzoneserver-viewer-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - tzaas.connect.cofide.io
+  resources:
+  - trustzoneservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tzaas.connect.cofide.io
+  resources:
+  - trustzoneservers/status
+  verbs:
+  - get
+{{- end }}

--- a/charts/cofide-trust-zone-operator/templates/validating-admission-policy.yaml
+++ b/charts/cofide-trust-zone-operator/templates/validating-admission-policy.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.vap.enabled (semverCompare ">=1.30.0-0" .Capabilities.KubeVersion.GitVersion) }}
 {{- $prefix := required "vap.spireNamespacePrefix is required when vap.enabled=true" .Values.vap.spireNamespacePrefix }}
 {{- $gatewayNs := .Values.gateway.namespace }}
-{{- $operatorNs := .Release.Namespace }}
+{{- $helmReleaseNs := .Values.operator.namespace | default .Release.Namespace }}
 {{- $saName := include "cofide-trust-zone-operator.serviceAccountName" . }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -30,26 +30,26 @@ spec:
       - statefulsets
       - roles
       - rolebindings
-      operations:  ["CREATE", "UPDATE", "PATCH", "DELETE"]
+      operations:  ["CREATE", "UPDATE", "DELETE"]
     # Gateway resources
     - apiGroups:   ["gateway.networking.k8s.io"]
       apiVersions: ["*"]
       resources:   ["referencegrants", "tlsroutes"]
-      operations:  ["CREATE", "UPDATE", "PATCH", "DELETE"]
+      operations:  ["CREATE", "UPDATE", "DELETE"]
   matchConditions:
   - name: is-operator-service-account
     expression: >-
-      request.userInfo.username == "system:serviceaccount:{{ $operatorNs }}:{{ $saName }}"
+      request.userInfo.username == "system:serviceaccount:{{ .Release.Namespace }}:{{ $saName }}"
   validations:
-  # Core/apps/RBAC resources: restrict to SPIRE namespaces or the operator's own namespace.
-  # The operator namespace exception covers leader-election ConfigMaps/leases and events.
+  # Core/apps/RBAC resources: restrict to SPIRE namespaces or the Helm release namespace
+  # (used for Helm release state storage).
   - expression: >-
       !(request.resource.group in ["", "apps", "rbac.authorization.k8s.io"])
       || request.namespace.startsWith("{{ $prefix }}")
-      || request.namespace == "{{ $operatorNs }}"
+      || request.namespace == "{{ $helmReleaseNs }}"
     message: >-
       The operator may only manage core, apps, and RBAC resources in namespaces
-      starting with "{{ $prefix }}" or in its own namespace "{{ $operatorNs }}"
+      starting with "{{ $prefix }}" or in the Helm release namespace "{{ $helmReleaseNs }}"
     reason: Forbidden
   # Namespace creation/deletion: name must start with the prefix.
   - expression: >-

--- a/charts/cofide-trust-zone-operator/templates/validating-admission-policy.yaml
+++ b/charts/cofide-trust-zone-operator/templates/validating-admission-policy.yaml
@@ -1,0 +1,81 @@
+{{- if and .Values.vap.enabled (semverCompare ">=1.30.0-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- $prefix := required "vap.spireNamespacePrefix is required when vap.enabled=true" .Values.vap.spireNamespacePrefix }}
+{{- $gatewayNs := .Values.gateway.namespace }}
+{{- $operatorNs := .Release.Namespace }}
+{{- $saName := include "cofide-trust-zone-operator.serviceAccountName" . }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-operator-scope
+  labels:
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    # Namespace creation/deletion
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      resources:   ["namespaces"]
+      operations:  ["CREATE", "DELETE"]
+    # Core, apps, and RBAC namespace-scoped resources
+    - apiGroups:   ["", "apps", "rbac.authorization.k8s.io"]
+      apiVersions: ["*"]
+      resources:
+      - configmaps
+      - secrets
+      - serviceaccounts
+      - services
+      - deployments
+      - statefulsets
+      - roles
+      - rolebindings
+      operations:  ["CREATE", "UPDATE", "PATCH", "DELETE"]
+    # Gateway resources
+    - apiGroups:   ["gateway.networking.k8s.io"]
+      apiVersions: ["*"]
+      resources:   ["referencegrants", "tlsroutes"]
+      operations:  ["CREATE", "UPDATE", "PATCH", "DELETE"]
+  matchConditions:
+  - name: is-operator-service-account
+    expression: >-
+      request.userInfo.username == "system:serviceaccount:{{ $operatorNs }}:{{ $saName }}"
+  validations:
+  # Core/apps/RBAC resources: restrict to SPIRE namespaces or the operator's own namespace.
+  # The operator namespace exception covers leader-election ConfigMaps/leases and events.
+  - expression: >-
+      !(request.resource.group in ["", "apps", "rbac.authorization.k8s.io"])
+      || request.namespace.startsWith("{{ $prefix }}")
+      || request.namespace == "{{ $operatorNs }}"
+    message: >-
+      The operator may only manage core, apps, and RBAC resources in namespaces
+      starting with "{{ $prefix }}" or in its own namespace "{{ $operatorNs }}"
+    reason: Forbidden
+  # Namespace creation/deletion: name must start with the prefix.
+  - expression: >-
+      !(request.resource.group == "" && request.resource.resource == "namespaces")
+      || object.metadata.name.startsWith("{{ $prefix }}")
+    message: >-
+      The operator may only create or delete namespaces whose names start with "{{ $prefix }}"
+    reason: Forbidden
+  # Gateway resources: restrict to gateway namespace or SPIRE namespaces
+  # (TLSRoutes live in gateway namespace; ReferenceGrants live in SPIRE namespaces).
+  - expression: >-
+      request.resource.group != "gateway.networking.k8s.io"
+      || request.namespace == "{{ $gatewayNs }}"
+      || request.namespace.startsWith("{{ $prefix }}")
+    message: >-
+      The operator may only manage gateway resources in the "{{ $gatewayNs }}"
+      namespace or in namespaces starting with "{{ $prefix }}"
+    reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ include "cofide-trust-zone-operator.fullname" . }}-operator-scope-binding
+  labels:
+  {{- include "cofide-trust-zone-operator.labels" . | nindent 4 }}
+spec:
+  policyName: {{ include "cofide-trust-zone-operator.fullname" . }}-operator-scope
+  validationActions: [{{ .Values.vap.validationAction }}]
+{{- end }}

--- a/charts/cofide-trust-zone-operator/values.schema.json
+++ b/charts/cofide-trust-zone-operator/values.schema.json
@@ -62,9 +62,23 @@
           "type": "string",
           "description": "Base domain for Gateway API TLSRoutes.",
           "minLength": 1
+        },
+        "create": {
+          "type": "boolean",
+          "description": "Whether to create a Gateway resource for TZaaS traffic."
+        },
+        "className": {
+          "type": "string",
+          "description": "Name of the GatewayClass to use for the Gateway. The GatewayClass must be installed separately before deploying this chart.",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the Gateway resource that TLSRoutes will reference.",
+          "minLength": 1
         }
       },
-      "required": ["namespace", "baseDomain"]
+      "required": ["namespace", "baseDomain", "create", "className", "name"]
     },
     "healthProbe": {
       "type": "object",

--- a/charts/cofide-trust-zone-operator/values.schema.json
+++ b/charts/cofide-trust-zone-operator/values.schema.json
@@ -1,0 +1,320 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Cofide Trust Zone Operator Configuration Schema",
+  "type": "object",
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the chart name used in resource names and labels."
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the fully qualified app name used in resource names."
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "Image pull secrets for pulling the operator container image from private registries.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      }
+    },
+    "connect": {
+      "type": "object",
+      "description": "Connect control plane configuration.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "URL of the Connect instance. Required for Connect integration.",
+          "minLength": 1
+        },
+        "trustDomain": {
+          "type": "string",
+          "description": "Trust domain of the Connect instance. Required for Connect integration.",
+          "minLength": 1
+        },
+        "cluster": {
+          "type": "object",
+          "description": "Configuration identifying the cluster this operator manages.",
+          "properties": {
+            "clusterId": {
+              "type": "string",
+              "description": "ID of the cluster this operator is running in."
+            }
+          }
+        }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "description": "Gateway API configuration.",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Namespace for Gateway API resources."
+        },
+        "baseDomain": {
+          "type": "string",
+          "description": "Base domain for Gateway API TLSRoutes.",
+          "minLength": 1
+        }
+      },
+      "required": ["namespace", "baseDomain"]
+    },
+    "healthProbe": {
+      "type": "object",
+      "description": "Health probe configuration.",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "description": "Port on which the health probe endpoints are served."
+        }
+      },
+      "required": ["port"]
+    },
+    "leaderElection": {
+      "type": "object",
+      "description": "Leader election configuration.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable leader election for the operator. Should be enabled when running multiple replicas."
+        }
+      },
+      "required": ["enabled"]
+    },
+    "rbac": {
+      "type": "object",
+      "description": "RBAC configuration.",
+      "properties": {
+        "createAggregateRoles": {
+          "type": "boolean",
+          "description": "Whether to create the admin, editor and viewer aggregate ClusterRoles for TrustZoneServer resources."
+        }
+      },
+      "required": ["createAggregateRoles"]
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Additional annotations to add to the operator pod.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Additional labels to add to the operator pod.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "kubernetesClusterDomain": {
+      "type": "string",
+      "description": "The Kubernetes cluster domain.",
+      "default": "cluster.local"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "description": "Service account configuration for the operator.",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Whether to create a service account for the operator."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the service account to use. If empty and create is true, a name is generated using the fullname template."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service account.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "automount": {
+          "type": "boolean",
+          "description": "Whether to automount the service account token."
+        }
+      },
+      "required": ["create", "automount"]
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Metrics endpoint configuration.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable the metrics endpoint, metrics service, and associated RBAC."
+        },
+        "tls": {
+          "type": "object",
+          "description": "TLS certificate configuration for the metrics endpoint.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether to serve the metrics endpoint over HTTPS."
+            },
+            "certSecretName": {
+              "type": "string",
+              "description": "Name of an existing Secret containing tls.crt and tls.key. Required when metrics.tls.enabled=true."
+            },
+            "certManager": {
+              "type": "object",
+              "description": "Optional cert-manager integration to automatically provision the metrics TLS certificate.",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Whether to create a cert-manager Certificate resource to supply the metrics TLS secret."
+                },
+                "issuerName": {
+                  "type": "string",
+                  "description": "Name of the cert-manager Issuer or ClusterIssuer."
+                },
+                "issuerKind": {
+                  "type": "string",
+                  "description": "Kind of the cert-manager issuer.",
+                  "enum": ["Issuer", "ClusterIssuer"]
+                }
+              },
+              "required": ["enabled"]
+            }
+          },
+          "required": ["enabled"]
+        },
+        "service": {
+          "type": "object",
+          "description": "Configuration for the metrics service.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Kubernetes service type for the metrics endpoint.",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+            },
+            "ports": {
+              "type": "array",
+              "description": "Port definitions for the metrics service.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "port": {
+                    "type": "integer"
+                  },
+                  "protocol": {
+                    "type": "string"
+                  },
+                  "targetPort": {
+                    "type": "integer"
+                  }
+                },
+                "required": ["port", "protocol", "targetPort"]
+              }
+            }
+          },
+          "required": ["type", "ports"]
+        }
+      },
+      "required": ["enabled", "tls", "service"]
+    },
+    "trustZoneOperator": {
+      "type": "object",
+      "description": "Configuration for the Trust Zone Operator deployment.",
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "description": "Number of operator replicas to deploy.",
+          "minimum": 1
+        },
+        "manager": {
+          "type": "object",
+          "description": "Configuration for the manager container.",
+          "properties": {
+            "args": {
+              "type": "array",
+              "description": "Additional arguments to pass to the manager binary.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "image": {
+              "type": "object",
+              "description": "Container image configuration.",
+              "properties": {
+                "registry": {
+                  "type": "string",
+                  "description": "Container image registry."
+                },
+                "repository": {
+                  "type": "string",
+                  "description": "Container image repository."
+                },
+                "tag": {
+                  "type": "string",
+                  "description": "Container image tag. Defaults to the chart appVersion if empty."
+                }
+              },
+              "required": ["registry", "repository"]
+            },
+            "imagePullPolicy": {
+              "type": "string",
+              "description": "Image pull policy.",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            },
+            "env": {
+              "type": "object",
+              "description": "Environment variable configuration for the manager container.",
+              "properties": {
+                "spiffeEndpointSocket": {
+                  "type": "string",
+                  "description": "SPIFFE endpoint socket path/URL for workload API access."
+                }
+              },
+              "required": ["spiffeEndpointSocket"]
+            },
+            "resources": {
+              "type": "object",
+              "description": "Compute resource requests and limits for the manager container."
+            },
+            "containerSecurityContext": {
+              "type": "object",
+              "description": "Security context for the manager container."
+            }
+          },
+          "required": ["image", "imagePullPolicy", "env"]
+        },
+        "podSecurityContext": {
+          "type": "object",
+          "description": "Security context for the operator pod."
+        },
+        "nodeSelector": {
+          "type": "object",
+          "description": "Node selector for the operator pod.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tolerations": {
+          "type": "array",
+          "description": "Tolerations for the operator pod.",
+          "items": {
+            "type": "object"
+          }
+        },
+        "topologySpreadConstraints": {
+          "type": "array",
+          "description": "Topology spread constraints for the operator pod.",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "required": ["replicas", "manager"]
+    }
+  },
+  "required": ["connect", "gateway", "kubernetesClusterDomain", "serviceAccount", "healthProbe", "leaderElection", "metrics", "trustZoneOperator", "rbac"]
+}

--- a/charts/cofide-trust-zone-operator/values.schema.json
+++ b/charts/cofide-trust-zone-operator/values.schema.json
@@ -99,6 +99,26 @@
       },
       "required": ["createAggregateRoles"]
     },
+    "vap": {
+      "type": "object",
+      "description": "ValidatingAdmissionPolicy configuration. Restricts the operator to only create/modify resources in designated namespaces. Requires Kubernetes >= 1.30.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to create the ValidatingAdmissionPolicy and binding."
+        },
+        "spireNamespacePrefix": {
+          "type": "string",
+          "description": "Prefix for SPIRE server namespaces. Required when vap.enabled=true. The operator will only be permitted to manage resources in namespaces whose names start with this prefix."
+        },
+        "validationAction": {
+          "type": "string",
+          "description": "Validation action: Deny (enforcing) or Warn (dry-run / audit mode).",
+          "enum": ["Deny", "Warn"]
+        }
+      },
+      "required": ["enabled", "validationAction"]
+    },
     "podAnnotations": {
       "type": "object",
       "description": "Additional annotations to add to the operator pod.",
@@ -316,5 +336,5 @@
       "required": ["replicas", "manager"]
     }
   },
-  "required": ["connect", "gateway", "kubernetesClusterDomain", "serviceAccount", "healthProbe", "leaderElection", "metrics", "trustZoneOperator", "rbac"]
+  "required": ["connect", "gateway", "kubernetesClusterDomain", "serviceAccount", "healthProbe", "leaderElection", "metrics", "trustZoneOperator", "rbac", "vap"]
 }

--- a/charts/cofide-trust-zone-operator/values.yaml
+++ b/charts/cofide-trust-zone-operator/values.yaml
@@ -57,6 +57,15 @@ gateway:
   className: ""
   # Name of the Gateway resource that TLSRoutes will reference.
   name: "tzaas-gateway"
+  # EnvoyProxy configuration for the Gateway.
+  # When envoyProxy.name is set, a matching EnvoyProxy CR is created in the gateway namespace
+  # and the Gateway is configured to reference it via spec.infrastructure.parametersRef,
+  # causing Envoy Gateway to create a proxy service of the configured type.
+  envoyProxy:
+    # Name of the EnvoyProxy CR to create and reference. Leave empty to disable.
+    name: ""
+    # Envoy proxy service type.
+    serviceType: LoadBalancer
 
 # Health probe configuration.
 healthProbe:

--- a/charts/cofide-trust-zone-operator/values.yaml
+++ b/charts/cofide-trust-zone-operator/values.yaml
@@ -25,12 +25,20 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template.
   name: ""
 
+# Operator configuration.
+operator:
+  # Namespace used for Helm release state storage.
+  # Defaults to the release namespace if not set.
+  namespace: ""
+
 # Connect control plane configuration.
 connect:
   # URL of the Connect instance.
   url: ""
   # Trust domain of the Connect instance.
   trustDomain: ""
+  # URL of the Connect bundle endpoint.
+  bundleUrl: ""
   # Configuration identifying the cluster this operator manages.
   cluster:
     # ID of the cluster this operator is running in.

--- a/charts/cofide-trust-zone-operator/values.yaml
+++ b/charts/cofide-trust-zone-operator/values.yaml
@@ -42,6 +42,13 @@ gateway:
   namespace: cofide
   # Base domain for Gateway API TLSRoutes.
   baseDomain: ""
+  # Whether to create a Gateway resource for TZaaS traffic.
+  create: true
+  # Name of the GatewayClass to use for the Gateway. Required.
+  # The GatewayClass must be installed separately before deploying this chart.
+  className: ""
+  # Name of the Gateway resource that TLSRoutes will reference.
+  name: "tzaas-gateway"
 
 # Health probe configuration.
 healthProbe:

--- a/charts/cofide-trust-zone-operator/values.yaml
+++ b/charts/cofide-trust-zone-operator/values.yaml
@@ -1,0 +1,155 @@
+# Default values for cofide-trust-zone-operator.
+
+# Override the chart name used in resource names and labels.
+nameOverride: ""
+# Override the fully qualified app name used in resource names.
+fullnameOverride: ""
+
+# The Kubernetes cluster domain.
+kubernetesClusterDomain: cluster.local
+
+# Image pull secrets for pulling the operator image from private registries.
+# More information: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+
+# Service account configuration for the operator.
+# More information: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Whether to create a service account for the operator.
+  create: true
+  # Automatically mount the service account token.
+  automount: true
+  # Annotations to add to the service account.
+  annotations: {}
+  # Name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: ""
+
+# Connect control plane configuration.
+connect:
+  # URL of the Connect instance.
+  url: ""
+  # Trust domain of the Connect instance.
+  trustDomain: ""
+  # Configuration identifying the cluster this operator manages.
+  cluster:
+    # ID of the cluster this operator is running in.
+    clusterId: ""
+
+# Gateway API configuration.
+gateway:
+  # Namespace for Gateway API resources.
+  namespace: cofide
+  # Base domain for Gateway API TLSRoutes.
+  baseDomain: ""
+
+# Health probe configuration.
+healthProbe:
+  # Port on which the health probe endpoints are served.
+  port: 8081
+
+# Leader election configuration.
+leaderElection:
+  # Whether to enable leader election for the operator. Should be enabled when running multiple replicas.
+  enabled: true
+
+# RBAC configuration.
+rbac:
+  # Whether to create the admin, editor and viewer aggregate ClusterRoles for TrustZoneServer resources.
+  createAggregateRoles: true
+
+# Metrics endpoint configuration.
+metrics:
+  # Whether to enable the metrics endpoint, metrics service, and associated RBAC.
+  enabled: true
+  # TLS certificate configuration for the metrics endpoint.
+  tls:
+    # Whether to serve the metrics endpoint over HTTPS.
+    enabled: true
+    # Name of an existing Secret containing tls.crt and tls.key.
+    # Required when metrics.tls.enabled=true (unless metrics.tls.certManager.enabled=true, which creates it).
+    # Set metrics.tls.enabled=false to disable TLS (e.g. local development).
+    certSecretName: ""
+    # Optional cert-manager integration to automatically provision the metrics TLS certificate.
+    certManager:
+      # Whether to create a cert-manager Certificate resource to supply the metrics TLS secret.
+      # Requires cert-manager to be installed. The Certificate will populate the secret named
+      # by metrics.tls.certSecretName.
+      enabled: false
+      issuerName: ""
+      issuerKind: ClusterIssuer
+  # Configuration for the metrics service.
+  service:
+    type: ClusterIP
+    ports:
+    - port: 8443
+      protocol: TCP
+      targetPort: 8443
+
+# Additional annotations to add to the operator pod.
+# More information: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# Additional labels to add to the operator pod.
+# More information: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+# Configuration for the Trust Zone Operator deployment.
+trustZoneOperator:
+  # Number of operator replicas to deploy.
+  replicas: 1
+
+  # Pod-level security context.
+  podSecurityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
+  # Node selector for the operator pod.
+  nodeSelector: {}
+
+  # Tolerations for the operator pod.
+  tolerations: []
+
+  # Topology spread constraints for the operator pod.
+  topologySpreadConstraints: []
+
+  # Configuration for the manager container.
+  manager:
+    image:
+      # Container image registry.
+      registry: 010438484483.dkr.ecr.eu-west-1.amazonaws.com
+      # Container image repository.
+      repository: cofide/trust-zone-operator
+      # Container image tag. Defaults to the chart appVersion if empty.
+      tag: ""
+
+    # Image pull policy.
+    imagePullPolicy: IfNotPresent
+
+    # Additional arguments to pass to the manager binary. The chart appends --health-probe-bind-address,
+    # --connect-url, --connect-trust-domain, --gateway-namespace, --gateway-base-domain,
+    # --leader-elect (if leaderElection.enabled), --metrics-bind-address/--metrics-secure
+    # (if metrics.enabled), and --metrics-cert-path (if metrics.tls.enabled and metrics.tls.certSecretName is set) automatically.
+    args: []
+
+    # Environment variable configuration for the manager container.
+    env:
+      # SPIFFE endpoint socket path/URL for workload API access.
+      spiffeEndpointSocket: unix:///spiffe-workload-api/spire-agent.sock
+
+    # Container-level security context.
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      readOnlyRootFilesystem: true
+
+    # Compute resource requests and limits.
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi

--- a/charts/cofide-trust-zone-operator/values.yaml
+++ b/charts/cofide-trust-zone-operator/values.yaml
@@ -58,6 +58,20 @@ rbac:
   # Whether to create the admin, editor and viewer aggregate ClusterRoles for TrustZoneServer resources.
   createAggregateRoles: true
 
+# ValidatingAdmissionPolicy configuration.
+# Restricts the operator to only create/modify resources in designated namespaces.
+# Requires Kubernetes >= 1.30 (ValidatingAdmissionPolicy is GA). Skipped automatically on older clusters.
+vap:
+  # Whether to create the ValidatingAdmissionPolicy and binding.
+  enabled: true
+  # Prefix for SPIRE server namespaces. Required when vap.enabled=true.
+  # The operator will only be permitted to manage resources in namespaces whose names
+  # start with this prefix (plus the gateway namespace and the operator's own namespace).
+  spireNamespacePrefix: ""
+  # Validation action: Deny (enforcing) or Warn (dry-run / audit mode).
+  # Use Warn during initial rollout to observe policy hits before switching to Deny.
+  validationAction: Deny
+
 # Metrics endpoint configuration.
 metrics:
   # Whether to enable the metrics endpoint, metrics service, and associated RBAC.

--- a/charts/cofide-tzaas-crds/.helmignore
+++ b/charts/cofide-tzaas-crds/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cofide-tzaas-crds/Chart.yaml
+++ b/charts/cofide-tzaas-crds/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: cofide-tzaas-crds
+description: Helm chart to install CRDs for the Cofide Trust Zone Operator
+type: application
+version: 0.1.0
+# appVersion tracks the version of the cofide-trust-zone-operator chart that these CRDs were released alongside.
+appVersion: "0.1.0"
+
+maintainers:
+  - name: Cofide
+    url: https://cofide.io

--- a/charts/cofide-tzaas-crds/templates/NOTES.txt
+++ b/charts/cofide-tzaas-crds/templates/NOTES.txt
@@ -1,0 +1,14 @@
+The Cofide TZaaS CRDs have been installed.
+
+To verify the CRDs are available:
+
+  kubectl get crd trustzoneservers.tzaas.connect.cofide.io
+
+These CRDs are required by the cofide-trust-zone-operator chart. Install that chart next:
+
+  helm install cofide-trust-zone-operator cofide/cofide-trust-zone-operator
+
+NOTE: Helm does not upgrade CRDs during 'helm upgrade'. To update the CRDs to a
+newer version, apply them directly using helm template piped to kubectl:
+
+  helm template cofide-tzaas-crds cofide/cofide-tzaas-crds | kubectl apply --server-side -f -

--- a/charts/cofide-tzaas-crds/templates/_helpers.tpl
+++ b/charts/cofide-tzaas-crds/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cofide-tzaas-crds.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cofide-tzaas-crds.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cofide-tzaas-crds.labels" -}}
+helm.sh/chart: {{ include "cofide-tzaas-crds.chart" . }}
+{{ include "cofide-tzaas-crds.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cofide-tzaas-crds.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cofide-tzaas-crds.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/charts/cofide-tzaas-crds/templates/trustzoneserver-crd.yaml
+++ b/charts/cofide-tzaas-crds/templates/trustzoneserver-crd.yaml
@@ -1,0 +1,206 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: trustzoneservers.tzaas.connect.cofide.io
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+  {{- include "cofide-tzaas-crds.labels" . | nindent 4 }}
+spec:
+  group: tzaas.connect.cofide.io
+  names:
+    kind: TrustZoneServer
+    listKind: TrustZoneServerList
+    plural: trustzoneservers
+    singular: trustzoneserver
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TrustZoneServer is the Schema for the trustzoneservers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of TrustZoneServer
+            properties:
+              connect:
+                description: connect contains the settings required for the TrustZoneServer
+                  to connect to the Connect control plane
+                properties:
+                  auth:
+                    description: auth contains the authentication settings used to connect
+                      to the Connect control plane
+                    properties:
+                      joinToken:
+                        description: joinToken is the token used for authentication
+                          when method is "join_token"
+                        type: string
+                      method:
+                        default: psat
+                        description: method is the authentication method used to connect
+                          to the Connect control plane
+                        enum:
+                        - psat
+                        - join_token
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: joinToken must be not be present when method is 'psat'
+                      rule: '!(self.method == "psat") || !has(self.joinToken)'
+                    - message: joinToken must be set when method is 'join_token'
+                      rule: '!(self.method == "join_token") || self.joinToken != ""'
+                  bundleEndpointURL:
+                    description: bundleEndpointURL is the URL from which to fetch Connect
+                      API trust bundle
+                    minLength: 1
+                    type: string
+                  trustDomain:
+                    description: trustDomain is the trust domain of the Connect API
+                    minLength: 1
+                    type: string
+                  url:
+                    description: url is the URL used by the TrustZone server to connect
+                      to the Connect control plane
+                    minLength: 1
+                    type: string
+                required:
+                - bundleEndpointURL
+                - trustDomain
+                - url
+                type: object
+              helmValues:
+                description: helmValues is a map of additional values to be passed to
+                  the Helm chart
+                x-kubernetes-preserve-unknown-fields: true
+              id:
+                description: id is the Connect-side identifier of the managed TrustZoneServer
+                minLength: 1
+                type: string
+              namespace:
+                description: namespace is the namespace where the TrustZoneServer will
+                  be deployed
+                maxLength: 63
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              serviceAccountName:
+                description: serviceAccountName is the service account to be used by
+                  the TrustZoneServer
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              trustDomain:
+                description: trustDomain is the trust domain associated with the TrustZoneServer
+                minLength: 1
+                type: string
+              trustZoneID:
+                description: trustZoneID is the Connect-side identifier of the TrustZone
+                  which the TrustZoneServer hosts
+                minLength: 1
+                type: string
+            required:
+            - connect
+            - id
+            - namespace
+            - serviceAccountName
+            - trustDomain
+            - trustZoneID
+            type: object
+          status:
+            description: status defines the observed state of TrustZoneServer
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the TrustZoneServer resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+  
+                  Condition types are as follows:
+                  - "GatewayAPIResourcesDeployed": indicates whether the Gateway API resources for the TrustZoneServer have been successfully deployed.
+                  - "SPIREServerDeployed": indicates whether the SPIRE server for the TrustZoneServer has been successfully deployed (i.e., all pods created and started, not necessarily functional or even currently running).
+                  - "SPIREServerHealthy": indicates whether the SPIRE server for the TrustZoneServer is healthy (i.e., all pods are running and ready).
+  
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/cofide-tzaas-crds/values.schema.json
+++ b/charts/cofide-tzaas-crds/values.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Cofide TZaaS CRDs Configuration Schema",
+  "type": "object",
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the chart name used in resource names and labels."
+    }
+  },
+  "additionalProperties": false
+}

--- a/charts/cofide-tzaas-crds/values.yaml
+++ b/charts/cofide-tzaas-crds/values.yaml
@@ -1,0 +1,1 @@
+nameOverride: ""


### PR DESCRIPTION
Adds helm charts for both the trust-zone-operator (that manages multiple SPIRE server deployments for separate trust domains) and the corresponding CRDs (latest practice with CRDs is to deploy them as a separate helm chart rather than with operators that use them so the removal of an operator doesn't immediately trigger the removal of all CRDs.

Helm charts produced by running generated manifests from kubebuilder through helmify (as it produces more readable helm charts than using the helm plugin for kubebuilder).

Key additions beyond the generated manifests:
- Optionally create certificate for metrics server if enabled (makes it easier to setup the metrics server for users already using cert-manager).
- Optionally setup gateway+envoyproxy (makes it easier to setup these resources if users don't want to set them separately / use an existing one).
- Validating admission policy used to restrict the otherwise very wide cluster level permissions that are granted to the operator (constrained to namespaces beginning with a specific prefix).