### PR TITLE
Make federated service TLS mode required

### DIFF
--- a/charts/cofide-agent/Chart.yaml
+++ b/charts/cofide-agent/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.4
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.43.0"
+appVersion: "v0.46.0"
 
 maintainers:
   - name: Cofide

--- a/charts/cofide-agent/crds/federatedservices.yaml
+++ b/charts/cofide-agent/crds/federatedservices.yaml
@@ -85,6 +85,7 @@ spec:
             - namespace
             - port
             - workloadLabels
+            - tlsMode
             type: object
           status:
             description: FederatedServiceStatus defines the observed state of FederatedService


### PR DESCRIPTION
Makes the TLS mode on FederatedService CRs a required field.

This stops the default behaviour from being defined within the controller, and makes the consumer explicitly opt-in to whether TLS is terminated at the application or Istio sidecar.

Depends on pending changes in the agent here https://github.com/cofide/cofide-connect/pull/1823 - to be released when the agent is released.