### PR TITLE
Add spiffe ids to federated services

### DIFF
--- a/charts/cofide-agent/Chart.yaml
+++ b/charts/cofide-agent/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.46.0"
+appVersion: "v0.48.0"
 
 maintainers:
   - name: Cofide

--- a/charts/cofide-agent/crds/federatedservices.yaml
+++ b/charts/cofide-agent/crds/federatedservices.yaml
@@ -74,6 +74,7 @@ spec:
                   references.
                 items:
                   type: string
+                minItems: 1
                 type: array
               tlsMode:
                 description: TLSMode defines the TLS mode for a federated service.

--- a/charts/cofide-agent/crds/federatedservices.yaml
+++ b/charts/cofide-agent/crds/federatedservices.yaml
@@ -71,7 +71,7 @@ spec:
                 type: integer
               spiffeIDPaths:
                 description: The SPIFFE ID Paths of the servers the federated service
-                  references.
+                  references. Leading slashes are optional.
                 items:
                   type: string
                 minItems: 1

--- a/charts/cofide-agent/crds/federatedservices.yaml
+++ b/charts/cofide-agent/crds/federatedservices.yaml
@@ -69,6 +69,11 @@ spec:
               port:
                 format: int32
                 type: integer
+              spiffeIDs:
+                description: The SPIFFE IDs of the servers the federated service references.
+                items:
+                  type: string
+                type: array
               tlsMode:
                 description: TLSMode defines the TLS mode for a federated service.
                 enum:
@@ -84,8 +89,9 @@ spec:
             - name
             - namespace
             - port
-            - workloadLabels
+            - spiffeIDs
             - tlsMode
+            - workloadLabels
             type: object
           status:
             description: FederatedServiceStatus defines the observed state of FederatedService

--- a/charts/cofide-agent/crds/federatedservices.yaml
+++ b/charts/cofide-agent/crds/federatedservices.yaml
@@ -69,8 +69,9 @@ spec:
               port:
                 format: int32
                 type: integer
-              spiffeIDs:
-                description: The SPIFFE IDs of the servers the federated service references.
+              spiffeIDPaths:
+                description: The SPIFFE ID Paths of the servers the federated service
+                  references.
                 items:
                   type: string
                 type: array
@@ -89,7 +90,7 @@ spec:
             - name
             - namespace
             - port
-            - spiffeIDs
+            - spiffeIDPaths
             - tlsMode
             - workloadLabels
             type: object


### PR DESCRIPTION
Depends on https://github.com/cofide/cofide-connect/pull/1854 and https://github.com/cofide/cofide-connect/pull/1859

This allows the user to specify the spiffe ID(s) of the servers the federated service references.

Existing users will need to manually apply the CRDs as Helm doesn't update CRDs automatically.