### PR TITLE
Expose source IP to Connect

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.2
+version: 0.12.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -150,6 +150,12 @@ data:
                     forward_client_cert_details: ALWAYS_FORWARD_ONLY
                     route_config:
                       name: local_route
+                      request_headers_to_remove:
+                        - x-source-ip
+                      request_headers_to_add:
+                        - header:
+                            key: x-source-ip
+                            value: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
                       virtual_hosts:
                         - name: grpc_services
                           domains:
@@ -310,6 +316,12 @@ data:
                       uri: true
                     route_config:
                       name: mtls_route
+                      request_headers_to_remove:
+                        - x-source-ip
+                      request_headers_to_add:
+                        - header:
+                            key: x-source-ip
+                            value: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
                       virtual_hosts:
                         - name: mtls_services
                           domains:

--- a/charts/cofide-connect/templates/service.yaml
+++ b/charts/cofide-connect/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- include "cofide-connect.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
     - name: proxy
       protocol: TCP

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -361,6 +361,26 @@
         "initialRBAC",
         "extraEnv"
       ]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+        },
+        "port": {
+          "type": "integer"
+        },
+        "externalTrafficPolicy": {
+          "type": "string",
+          "enum": ["Local", "Cluster"]
+        }
+      },
+      "required": ["type", "port"]
     }
   },
   "required": ["connect"]

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -178,6 +178,7 @@ service:
   annotations: {}
   type: LoadBalancer
   port: 8443
+  externalTrafficPolicy: Local
 
 # This is for setting Kubernetes Annotations to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/


### PR DESCRIPTION
Part of https://github.com/cofide/cofide-connect/issues/1874

Required to support capturing source IPs here https://github.com/cofide/cofide-connect/pull/1872

Exposes the source IP of the request to Connect - so it can be logged as part of audit events. This is a required field in the OCSF schema and so is needed in order for audit events to be send to an OCSF compatible sink.

Cloud load balancers such as those from GCP and AWS should populate the `DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT` header when the service's external traffic policy is "Local" and therefore Envoy can propagate this through to Connect.