### PR TITLE
Expose source IP to Connect using PROXY protocol

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.2
+version: 0.13.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -49,6 +49,11 @@ data:
               address: 0.0.0.0
               port_value: 8443
           listener_filters:
+            {{- if .Values.service.proxyProtocol.enabled }}
+            - name: envoy.filters.listener.proxy_protocol
+              typed_config:
+                '@type': type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol
+            {{- end }}
             - name: envoy.filters.listener.tls_inspector
               typed_config:
                 '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
@@ -150,6 +155,12 @@ data:
                     forward_client_cert_details: ALWAYS_FORWARD_ONLY
                     route_config:
                       name: local_route
+                      request_headers_to_remove:
+                        - x-source-ip
+                      request_headers_to_add:
+                        - header:
+                            key: x-source-ip
+                            value: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
                       virtual_hosts:
                         - name: grpc_services
                           domains:
@@ -310,6 +321,12 @@ data:
                       uri: true
                     route_config:
                       name: mtls_route
+                      request_headers_to_remove:
+                        - x-source-ip
+                      request_headers_to_add:
+                        - header:
+                            key: x-source-ip
+                            value: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
                       virtual_hosts:
                         - name: mtls_services
                           domains:

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -361,6 +361,33 @@
         "initialRBAC",
         "extraEnv"
       ]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+        },
+        "port": {
+          "type": "integer"
+        },
+        "proxyProtocol": {
+          "type": "object",
+          "description": "PROXY protocol configuration for the Envoy listener.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable PROXY protocol on the Envoy listener. Requires the upstream load balancer to send PROXY protocol headers."
+            }
+          },
+          "required": ["enabled"]
+        }
+      },
+      "required": ["type", "port"]
     }
   },
   "required": ["connect"]

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -175,9 +175,24 @@ serviceAccount:
   name: ""
 
 service:
+  # Annotations to add to the Service.
+  # When proxyProtocol.enabled is true, the load balancer must also be configured to send PROXY
+  # protocol headers. The Envoy proxy handles both PROXY protocol v1 and v2 automatically.
+  # Cloud provider-specific annotations or configuration is required:
+  # AWS NLB (in-tree cloud provider or AWS Load Balancer Controller) sends PROXY protocol v2:
+  #   service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  # GCP: the default passthrough NLB does not support PROXY protocol. Use a TCP Proxy Load
+  # Balancer and reference a BackendConfig that enables proxyHeader: PROXY_V1 (the only version
+  # supported by GCP) with:
+  #   cloud.google.com/backend-config: '{"default": "<backend-config-name>"}'
   annotations: {}
   type: LoadBalancer
   port: 8443
+  proxyProtocol:
+    # Enable PROXY protocol on the Envoy listener. Requires the upstream load balancer to send
+    # PROXY protocol headers. Disable in environments that do not support it (e.g. kind with
+    # cloud-provider-kind). Source IP is required for audit events so this is enabled by default.
+    enabled: true
 
 # This is for setting Kubernetes Annotations to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/


### PR DESCRIPTION
Alternative to https://github.com/cofide/helm-charts/pull/105 that uses [PROXY protocol](https://www.haproxy.com/blog/use-the-proxy-protocol-to-preserve-a-clients-ip-address) instead of a local external traffic policy.

Part of https://github.com/cofide/cofide-connect/issues/1874

Required to support capturing source IPs here https://github.com/cofide/cofide-connect/pull/1872

Source IPs are exposed using PROXY protocol which is supported by most cloud providers on their network (L4) load balancers (aws, gcp, azure, digital ocean, oracle cloud) and ingress controllers / service meshes (nginx, envoy proxy, istio, traefik, haproxy (originator of protocol), kong).

The other alternative is using external traffic policy local - but that in turn requires more configuration/tuning of the relationship between the workloads and the load balancers to ensure traffic is not sent to a node without a pod to receive the traffic.