### PR TITLE
Add toggleable source IP preservation for Connect

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.2
+version: 0.13.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -49,6 +49,11 @@ data:
               address: 0.0.0.0
               port_value: 8443
           listener_filters:
+            {{- if .Values.envoy.proxyProtocol.enabled }}
+            - name: envoy.filters.listener.proxy_protocol
+              typed_config:
+                '@type': type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol
+            {{- end }}
             - name: envoy.filters.listener.tls_inspector
               typed_config:
                 '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
@@ -150,6 +155,14 @@ data:
                     forward_client_cert_details: ALWAYS_FORWARD_ONLY
                     route_config:
                       name: local_route
+                      request_headers_to_remove:
+                        - x-source-ip
+                      {{- if or .Values.envoy.proxyProtocol.enabled (eq .Values.service.externalTrafficPolicy "Local") }}
+                      request_headers_to_add:
+                        - header:
+                            key: x-source-ip
+                            value: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
+                      {{- end }}
                       virtual_hosts:
                         - name: grpc_services
                           domains:
@@ -310,6 +323,14 @@ data:
                       uri: true
                     route_config:
                       name: mtls_route
+                      request_headers_to_remove:
+                        - x-source-ip
+                      {{- if or .Values.envoy.proxyProtocol.enabled (eq .Values.service.externalTrafficPolicy "Local") }}
+                      request_headers_to_add:
+                        - header:
+                            key: x-source-ip
+                            value: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
+                      {{- end }}
                       virtual_hosts:
                         - name: mtls_services
                           domains:

--- a/charts/cofide-connect/templates/service.yaml
+++ b/charts/cofide-connect/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- include "cofide-connect.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
     - name: proxy
       protocol: TCP

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -361,6 +361,43 @@
         "initialRBAC",
         "extraEnv"
       ]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+        },
+        "port": {
+          "type": "integer"
+        },
+        "externalTrafficPolicy": {
+          "type": "string",
+          "enum": ["Local", "Cluster"],
+          "description": "Controls how traffic is routed from external load balancers. Set to Local to preserve the original client source IP."
+        }
+      },
+      "required": ["type", "port", "externalTrafficPolicy"]
+    },
+    "envoy": {
+      "type": "object",
+      "properties": {
+        "proxyProtocol": {
+          "type": "object",
+          "description": "PROXY protocol configuration for the Envoy listener.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable PROXY protocol on the Envoy listener. Requires the upstream load balancer to send PROXY protocol headers."
+            }
+          },
+          "required": ["enabled"]
+        }
+      }
     }
   },
   "required": ["connect"]

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -144,6 +144,11 @@ envoy:
       - profile
       - offline_access
       - email
+  proxyProtocol:
+    # Enable PROXY protocol on the Envoy listener. When enabled, Envoy unwraps the PROXY header
+    # to obtain the original client source IP. The upstream load balancer must be configured to
+    # send PROXY protocol headers - see the annotations examples above.
+    enabled: false
   logLevel: "info"
   securityContext: {}
   resources: {}
@@ -175,9 +180,46 @@ serviceAccount:
   name: ""
 
 service:
+  # Annotations to add to the Service.
+  # When proxyProtocol.enabled is true, cloud-provider annotations are needed to configure the
+  # load balancer to send PROXY protocol headers. Examples:
+  #
+  # AWS NLB (in-tree cloud provider or AWS Load Balancer Controller) - sends PROXY protocol v2:
+  #   annotations:
+  #     service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  #
+  # GCP: the default passthrough NLB does not support PROXY protocol. Switch to a TCP Proxy load
+  # balancer and reference a BackendConfig CR that enables proxyHeader: PROXY_V1 (the only version
+  # GCP supports):
+  #   annotations:
+  #     cloud.google.com/backend-config: '{"default": "connect-backend-config"}'
+  #     cloud.google.com/load-balancer-type: "External"
+  # Create the BackendConfig separately in the same namespace:
+  #   apiVersion: cloud.google.com/v1
+  #   kind: BackendConfig
+  #   metadata:
+  #     name: connect-backend-config
+  #   spec:
+  #     customRequestHeaders:
+  #       headers:
+  #         - "X-Forwarded-Proto: https"
+  #     # proxyHeader instructs the TCP Proxy load balancer to prepend a PROXY protocol header.
+  #     # Only PROXY_V1 is supported by GCP.
+  #     # Note: requires the Service to use a TCP Proxy (not passthrough) load balancer.
+  #
+  # When externalTrafficPolicy is Local (below), no additional annotations are required on most
+  # cloud providers - node-local routing is a native Kubernetes feature.
   annotations: {}
   type: LoadBalancer
   port: 8443
+  # externalTrafficPolicy controls how traffic from external load balancers is routed to pods.
+  # Set to Local to preserve the original client source IP by bypassing kube-proxy SNAT.
+  # Requires pods to be spread across nodes, as traffic is dropped for nodes with no ready pod.
+  # Kubernetes provisions a healthCheckNodePort so the load balancer can identify nodes with a
+  # ready pod. Most cloud controllers (GCP, AWS NLB, Azure) configure the LB health check against
+  # this port automatically, so no additional annotations should be required - but verify this
+  # holds for your environment and cloud controller version.
+  externalTrafficPolicy: Cluster
 
 # This is for setting Kubernetes Annotations to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/


### PR DESCRIPTION
Replaces https://github.com/cofide/helm-charts/pull/105 and https://github.com/cofide/helm-charts/pull/106.

Tested by https://github.com/cofide/cofide-connect/pull/1880

Combines the PROXY protocol and externalTrafficPolicy=Local approaches into a single chart, with both disabled by default to preserve current behaviour. Customers can enable whichever method their load balancer supports:

- service.proxyProtocol.enabled: true - load balancer sends PROXY protocol headers (AWS NLB, GCP TCP Proxy, nginx, traefik, etc.)
- service.externalTrafficPolicy: Local - load balancer supports node-local routing without additional protocol overhead

When either method is active, Envoy injects the preserved source IP into an x-source-ip request header forwarded to the Connect API.