### PR TITLE
Add Content-Security-Policy header via Envoy sidecar

### DIFF
--- a/charts/cofide-connect-ui/Chart.yaml
+++ b/charts/cofide-connect-ui/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect-ui/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect-ui/templates/configmap-envoy.yaml
@@ -52,6 +52,11 @@ data:
                         - name: ui_service
                           domains:
                             - '*'
+                          response_headers_to_add:
+                            - header:
+                                key: Content-Security-Policy
+                                value: "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; connect-src 'self' {{ .Values.ui.connectUrl }} {{ .Values.ui.oauth.issuer }};"
+                              keep_empty_value: false
                           routes:
                             - match:
                                 prefix: /


### PR DESCRIPTION
Adds a CSP to mitigate XSS token theft, scoped to the API and OIDC issuer URLs already required by the Helm chart.

---

Further context on what the impact of this should be:

CSP doesn't prevent the injected script from reading the token or using it within the current session. An attacker with XSS could still make API calls to the whitelisted backend directly, or read data rendered in the DOM. The protection is specifically against token theft for later use - taking the token away to use from a different machine or after the session ends.

That's why script-src 'self' is the more valuable of the two directives here: if scripts can't be injected in the first place, the token is never at risk.