### PR TITLE
feat(cofide-connect): forward client cert details for XDS path

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -111,6 +111,9 @@ data:
                     stream_idle_timeout: 3600s
                     stat_prefix: grpc_json
                     codec_type: AUTO
+                    forward_client_cert_details: SANITIZE_SET
+                    set_current_client_cert_details:
+                      uri: true
                     route_config:
                       name: local_route
                       virtual_hosts:


### PR DESCRIPTION
Add XFCC header forwarding to the connect_xds_api envoy filter chain,
matching the existing configuration in connect_agent_api.

This will allow us to use the client's SPIFFE ID as the xDS node ID.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
