### PR TITLE
fix(cofide-credex): use root context in with blocks to fix template rendering

### DIFF
--- a/charts/cofide-credex/Chart.yaml
+++ b/charts/cofide-credex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cofide-credex
 description: Helm chart to deploy Cofide Credex
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.11.0"
 maintainers:
   - name: Cofide

--- a/charts/cofide-credex/templates/configmap.yaml
+++ b/charts/cofide-credex/templates/configmap.yaml
@@ -41,9 +41,9 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "cofide-credex.fullname" . }}-extra-ca
+  name: {{ include "cofide-credex.fullname" $ }}-extra-ca
   labels:
-    {{- include "cofide-credex.labels" . | nindent 4 }}
+    {{- include "cofide-credex.labels" $ | nindent 4 }}
 data:
   ca.crt: |
     {{- . | nindent 4 }}

--- a/charts/cofide-credex/templates/deployment.yaml
+++ b/charts/cofide-credex/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
         {{- with .Values.credex.extraCA }}
         - name: extra-ca
           configMap:
-            name: {{ include "cofide-credex.fullname" . }}-extra-ca
+            name: {{ include "cofide-credex.fullname" $ }}-extra-ca
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Inside {{- with .Values.credex.extraCA }} blocks, . is rebound to the
extraCA string value, causing include calls that access .Values to fail.
Use $ (root context) instead.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
