### PR TITLE
feat(cofide-credex): add SPIRE agent admin socket volume support

### DIFF
--- a/charts/cofide-credex/Chart.yaml
+++ b/charts/cofide-credex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cofide-credex
 description: Helm chart to deploy Cofide Credex
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.11.0"
 maintainers:
   - name: Cofide

--- a/charts/cofide-credex/README.md
+++ b/charts/cofide-credex/README.md
@@ -49,7 +49,8 @@ helm install cofide-credex cofide/cofide-credex \
 | Value | Description | Required |
 |---|---|---|
 | `credex.baseDomain` | Base domain for the custom token exchange endpoint | Yes |
-| `credex.spireAgentAdminSocket` | SPIRE Agent admin socket path | Yes |
+| `credex.spireAgentAdminSocket` | SPIRE Agent admin socket path inside the container. Defaults to `unix:///run/spire/private/sockets/admin.sock` | No |
+| `credex.spireAgentAdminSocketHostPath` | Host path for the SPIRE Agent admin socket. Enables Delegation API access. | Yes |
 
 ### Trusted Issuers
 

--- a/charts/cofide-credex/templates/configmap.yaml
+++ b/charts/cofide-credex/templates/configmap.yaml
@@ -17,8 +17,8 @@ data:
   {{- with .Values.credex.baseDomain }}
   BASE_DOMAIN: {{ . | quote }}
   {{- end }}
-  {{- with .Values.credex.spireAgentAdminSocket }}
-  SPIRE_AGENT_ADMIN_SOCKET: {{ . | quote }}
+  {{- with .Values.credex.spireAgentAdminSocketHostPath }}
+  SPIRE_AGENT_ADMIN_SOCKET: {{ $.Values.credex.spireAgentAdminSocket | quote }}
   {{- end }}
   {{- with .Values.credex.policyConfigFile }}
   POLICY_CONFIG_FILE: {{ . | quote }}

--- a/charts/cofide-credex/templates/deployment.yaml
+++ b/charts/cofide-credex/templates/deployment.yaml
@@ -80,6 +80,11 @@ spec:
               subPath: ca.crt
               readOnly: true
             {{- end }}
+            {{- with $.Values.credex.spireAgentAdminSocketHostPath }}
+            - name: spire-agent-admin-socket-dir
+              mountPath: {{ $.Values.credex.spireAgentAdminSocket | trimPrefix "unix://" | dir }}
+              readOnly: true
+            {{- end }}
       volumes:
         - name: oauth-private-key
           secret:
@@ -91,6 +96,12 @@ spec:
         - name: extra-ca
           configMap:
             name: {{ include "cofide-credex.fullname" $ }}-extra-ca
+        {{- end }}
+        {{- with .Values.credex.spireAgentAdminSocketHostPath }}
+        - name: spire-agent-admin-socket-dir
+          hostPath:
+            path: {{ . }}
+            type: DirectoryOrCreate
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/cofide-credex/values.schema.json
+++ b/charts/cofide-credex/values.schema.json
@@ -53,7 +53,11 @@
         },
         "spireAgentAdminSocket": {
           "type": "string",
-          "description": "SPIRE Agent admin socket path. Required when enableCustomExchange is true."
+          "description": "SPIRE Agent admin socket path. Defaults to `unix:///run/spire/private/sockets/admin.sock`."
+        },
+        "spireAgentAdminSocketHostPath": {
+          "type": "string",
+          "description": "Host path to the SPIRE agent admin socket directory on the node. Setting this enables Delegation API access (required for enableCustomExchange: true). Also requires securityContext.runAsUser: 0."
         },
         "issuerURL": {
           "type": "string",
@@ -199,9 +203,9 @@
           "then": {
             "properties": {
               "baseDomain": { "type": "string", "minLength": 1 },
-              "spireAgentAdminSocket": { "type": "string", "minLength": 1 }
+              "spireAgentAdminSocketHostPath": { "type": "string", "minLength": 1 }
             },
-            "required": ["baseDomain", "spireAgentAdminSocket"]
+            "required": ["baseDomain", "spireAgentAdminSocketHostPath"]
           }
         },
         {

--- a/charts/cofide-credex/values.yaml
+++ b/charts/cofide-credex/values.yaml
@@ -17,9 +17,15 @@ credex:
   # Base domain for the custom token exchange endpoint.
   # Required when enableCustomExchange is true.
   baseDomain: ""
-  # SPIRE Agent admin socket path.
-  # Required when enableCustomExchange is true.
-  spireAgentAdminSocket: ""
+  # SPIRE Agent admin socket path inside the container.
+  # Defaults to a standard path; override only if needed.
+  # Also set spireAgentAdminSocketHostPath and securityContext.runAsUser: 0.
+  spireAgentAdminSocket: "unix:///run/spire/private/sockets/admin.sock"
+  # Host path to the SPIRE agent admin socket directory on the node.
+  # Setting this enables Delegation API access (required for enableCustomExchange: true).
+  # Also requires securityContext.runAsUser: 0.
+  # Example: /run/spire/agent/sockets/csi.spiffe.io/admin
+  spireAgentAdminSocketHostPath: ""
   # Issuer URL for the OAuth AS.
   # Required when enableOAuthAS is true.
   issuerURL: ""


### PR DESCRIPTION
Add hostPath volume and volumeMount for the SPIRE agent admin socket,
gated on the new spireAgentAdminSocketHostPath value. Set a sensible
default for spireAgentAdminSocket so only the host path needs to be
configured to enable Delegation API access.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
