### PR TITLE
feat: service annotations, extraEnv schema fix, just lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,12 @@ This file provides guidance to AI coding agents when working with code in this r
 Charts are linted using [chart-testing](https://github.com/helm/chart-testing). CI runs on every PR:
 
 ```bash
+just lint
+```
+
+Or (equivalent):
+
+```bash
 ct lint --config .ct.yaml
 ```
 

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,3 @@
+# Lint the Helm charts using chart-testing (ct)
+lint *args="--all":
+    ct lint --config .ct.yaml {{args}}

--- a/charts/cofide-credex/Chart.yaml
+++ b/charts/cofide-credex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cofide-credex
 description: Helm chart to deploy Cofide Credex
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "v0.11.0"
 maintainers:
   - name: Cofide

--- a/charts/cofide-credex/templates/service.yaml
+++ b/charts/cofide-credex/templates/service.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cofide-credex.fullname" . }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "cofide-credex.labels" . | nindent 4 }}
 spec:

--- a/charts/cofide-credex/values.schema.json
+++ b/charts/cofide-credex/values.schema.json
@@ -134,6 +134,7 @@
           "description": "Additional environment variables to pass to the credex binary.",
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "allOf": [
               {
                 "properties": {

--- a/charts/cofide-credex/values.schema.json
+++ b/charts/cofide-credex/values.schema.json
@@ -303,6 +303,13 @@
         "targetPort": {
           "type": "integer",
           "description": "Container port to forward traffic to."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "required": ["type", "port", "targetPort"]

--- a/charts/cofide-credex/values.yaml
+++ b/charts/cofide-credex/values.yaml
@@ -107,6 +107,7 @@ service:
   type: ClusterIP
   port: 80
   targetPort: 8080
+  annotations: {}
 
 # Liveness probe configuration.
 livenessProbe:


### PR DESCRIPTION
- **test: add a `just lint` target**
- **feat(cofide-credex): add support for service annotations**
- **fix(cofide-credex): JSON schema for extraEnv items**
