### PR TITLE
feat(cofide-connect): add support for fine-grained audit configuration

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.1
+version: 0.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.43.0"
+appVersion: "v0.51.0"
 
 maintainers:
   - name: Cofide

--- a/charts/cofide-connect/ci/audit-config-values.yaml
+++ b/charts/cofide-connect/ci/audit-config-values.yaml
@@ -1,0 +1,8 @@
+connect:
+  audit:
+    sinks:
+      connectDatastore:
+        enabledEvents:
+          - all
+        disabledEvents:
+          - trust_zone_creation

--- a/charts/cofide-connect/ci/required-values.yaml
+++ b/charts/cofide-connect/ci/required-values.yaml
@@ -1,0 +1,1 @@
+# Currently no values are required to be set.

--- a/charts/cofide-connect/templates/configmap.yaml
+++ b/charts/cofide-connect/templates/configmap.yaml
@@ -74,3 +74,20 @@ data:
           {{- end }}
       {{- end }}
     record_audit_events: {{ .Values.connect.recordAuditEvents | toString }}
+    audit:
+      sinks:
+        connect_datastore:
+          enabled_events:
+            {{- if .Values.connect.audit.sinks.connectDatastore.enabledEvents }}
+              {{- range .Values.connect.audit.sinks.connectDatastore.enabledEvents }}
+            - {{ . | quote }}
+              {{- end }}
+            {{- else }} []
+            {{- end }}
+          disabled_events:
+            {{- if .Values.connect.audit.sinks.connectDatastore.disabledEvents }}
+              {{- range .Values.connect.audit.sinks.connectDatastore.disabledEvents }}
+            - {{ . | quote }}
+              {{- end }}
+            {{- else }} []
+            {{- end }}

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -334,6 +334,42 @@
           "type": "boolean",
           "description": "Whether audit events should be recorded within Connect. If enabled all operations within Connect that change state (e.g. create/update/delete APIs, node attestation/deletion, workload creation/deletion) will be recorded."
         },
+        "audit": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Configures audit event recording and the sinks events are sent to.",
+          "properties": {
+            "sinks": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "connectDatastore": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabledEvents": {
+                      "type": "array",
+                      "description": "List of event types to enable. Use \"all\" to enable every event type.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "disabledEvents": {
+                      "type": "array",
+                      "description": "List of event types to disable. Subtracted from the resolved enabledEvents list.",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": ["enabledEvents", "disabledEvents"]
+                }
+              },
+              "required": ["connectDatastore"]
+            }
+          },
+          "required": ["sinks"]
+        },
         "extraEnv": {
           "type": "array",
           "description": "Additional environment variables to pass to the connect api binary.",
@@ -388,6 +424,7 @@
         "authzPolicyEngine",
         "initialRBAC",
         "recordAuditEvents",
+        "audit",
         "extraEnv"
       ]
     },

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -118,7 +118,18 @@ connect:
     #      subject: clusterAadmin@example.com
     roleBindings: []
   # Whether audit events should be recorded within Connect. If enabled all operations within Connect that change state (e.g. create/update/delete APIs, node attestation/deletion, workload creation/deletion) will be recorded.
+  # DEPRECATED: This flag is deprecated and will be removed in a future release. Use the `audit` configuration block instead.
   recordAuditEvents: false
+  # Audit configured audit event recording and the sinks events are sent to.
+  audit:
+    sinks:
+      connectDatastore:
+        # EnabledEvents is the list of event types to enable. Use "all" to enable every event type.
+        # Examples: trust_zone_creation, workload_deletion, cluster_creation, node_attestation.
+        enabledEvents: []
+        # DisabledEvents is subtracted from the resolved enabledEvents list.
+        # Examples: trust_zone_deletion, cluster_deletion.
+        disabledEvents: []
   # Additional environment variables to pass to connect api binary.
   # For example:
   #  extraEnv:


### PR DESCRIPTION
Introduces a new 'audit' configuration block under 'connect' to support
fine-grained control over audit event sinks and filtered event types.
The legacy 'recordAuditEvents' flag is marked as deprecated.

Updates:
- values.yaml: added 'audit' structure and deprecation notice.
- values.schema.json: added validation for the new fields.
- configmap.yaml: mapped Helm values to application config.
