### PR TITLE
Support RDS datastore

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.0
+version: 0.17.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.51.0"
+appVersion: "v0.53.0"
 
 maintainers:
   - name: Cofide

--- a/charts/cofide-connect/templates/configmap.yaml
+++ b/charts/cofide-connect/templates/configmap.yaml
@@ -53,6 +53,23 @@ data:
           service_account_name: {{ .serviceAccountName | quote }}
         {{- end }}
       {{- end }}
+      {{- with .Values.connect.datastore.rds }}
+      rds:
+        enabled: {{ .enabled }}
+        host: {{ .host | quote }}
+        port: {{ .port }}
+        database_name: {{ .databaseName | quote }}
+        db_user: {{ .dbUser | quote }}
+        {{- with .oidc }}
+        oidc:
+          aws_region: {{ .awsRegion | quote }}
+          iam_role_arn: {{ .iamRoleARN | quote }}
+          audience: {{ .audience | quote }}
+        {{- end }}
+        max_open_conns: {{ .maxOpenConns }}
+        conn_max_lifetime: {{ .connMaxLifetime | quote }}
+        conn_max_idle_time: {{ .connMaxIdleTime | quote }}
+      {{- end }}
     connect_psat_audience: {{ .Values.connect.connectPSATAudience }}
     connect_trust_domain: {{ .Values.connect.trustDomain }}
     connect_trust_bundle_store_url: {{ .Values.connect.connectTrustBundleStoreURL }}

--- a/charts/cofide-connect/templates/configmap.yaml
+++ b/charts/cofide-connect/templates/configmap.yaml
@@ -119,5 +119,5 @@ data:
             {{- else }} []
             {{- end }}
 {{- if ne $datastoreUsed 1 }}
-{{- fail (printf "You have to enable exactly one datastore. There are %d enabled." $datastoreUsed) }}
+{{- fail (printf "You must enable exactly one datastore. There are %d enabled." $datastoreUsed) }}
 {{- end }}

--- a/charts/cofide-connect/templates/configmap.yaml
+++ b/charts/cofide-connect/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- $datastoreUsed := 0 -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -35,12 +36,18 @@ data:
       {{- end }}
     datastore:
       {{- with .Values.connect.datastore.sqlConnectionString }}
+      {{- if .enabled }}
+        {{- $datastoreUsed = add $datastoreUsed 1 }}
+      {{- end }}
       sql_connection_string:
         enabled: {{ .enabled }}
         connection_string: {{ .connectionString | quote }}
         remote_spiffe_id: {{ .remoteSPIFFEID | quote }}
       {{- end }}
       {{- with .Values.connect.datastore.cloudSQL }}
+      {{- if .enabled }}
+        {{- $datastoreUsed = add $datastoreUsed 1 }}
+      {{- end }}
       cloudsql:
         enabled: {{ .enabled }}
         instance: {{ .instance | quote }}
@@ -54,6 +61,9 @@ data:
         {{- end }}
       {{- end }}
       {{- with .Values.connect.datastore.rds }}
+      {{- if .enabled }}
+        {{- $datastoreUsed = add $datastoreUsed 1 }}
+      {{- end }}
       rds:
         enabled: {{ .enabled }}
         host: {{ .host | quote }}
@@ -108,3 +118,6 @@ data:
               {{- end }}
             {{- else }} []
             {{- end }}
+{{- if ne $datastoreUsed 1 }}
+{{- fail (printf "You have to enable exactly one datastore. There are %d enabled." $datastoreUsed) }}
+{{- end }}

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -229,9 +229,85 @@
                 "pscEnabled",
                 "oidc"
               ]
+            },
+            "rds": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "AWS RDS configuration",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "True to enable AWS RDS as the datastore"
+                },
+                "host": {
+                  "type": "string",
+                  "description": "Hostname of the RDS instance"
+                },
+                "port": {
+                  "type": "integer",
+                  "description": "Port of the RDS instance"
+                },
+                "databaseName": {
+                  "type": "string",
+                  "description": "Name of the Connect database",
+                  "minLength": 1
+                },
+                "dbUser": {
+                  "type": "string",
+                  "description": "Database user to connect as (must have the rds_iam role granted)"
+                },
+                "oidc": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Configuration to use OIDC to access AWS RDS, exchanging the server's SVID for temporary IAM credentials",
+                  "properties": {
+                    "awsRegion": {
+                      "type": "string",
+                      "description": "AWS region of the RDS instance"
+                    },
+                    "iamRoleARN": {
+                      "type": "string",
+                      "description": "IAM role ARN to assume for database access"
+                    },
+                    "audience": {
+                      "type": "string",
+                      "description": "Audience expected by the OIDC provider in AWS"
+                    }
+                  },
+                  "required": [
+                    "awsRegion",
+                    "iamRoleARN",
+                    "audience"
+                  ]
+                },
+                "maxOpenConns": {
+                  "type": "integer",
+                  "description": "Maximum number of open connections in the pool per Connect instance.",
+                  "minimum": 1
+                },
+                "connMaxLifetime": {
+                  "type": "string",
+                  "description": "Maximum time a connection may be reused (Go duration string, e.g. \"5m\", \"1h\")."
+                },
+                "connMaxIdleTime": {
+                  "type": "string",
+                  "description": "Maximum time a connection may be idle before being closed (Go duration string, e.g. \"1m\")."
+                }
+              },
+              "required": [
+                "enabled",
+                "host",
+                "port",
+                "databaseName",
+                "dbUser",
+                "oidc",
+                "maxOpenConns",
+                "connMaxLifetime",
+                "connMaxIdleTime"
+              ]
             }
           },
-          "required": ["sqlConnectionString", "cloudSQL"]
+          "required": ["sqlConnectionString", "cloudSQL", "rds"]
         },
         "connectPSATAudience": {
           "type": "string",

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -93,6 +93,34 @@ connect:
         audience: ""
         # Name of service account with access privileges to the Connect database in CloudSQL
         serviceAccountName: ""
+    rds:
+      # True to enable AWS RDS as the datastore
+      enabled: false
+      # Hostname of the RDS instance
+      host: ""
+      # Port of the RDS instance
+      port: 5432
+      # Name of the Connect database
+      databaseName: "connect-db"
+      # Database user to connect as (must have the rds_iam role granted)
+      dbUser: ""
+      # Configuration to use OIDC to access AWS RDS, exchanging the server's SVID for temporary IAM credentials
+      oidc:
+        # AWS region of the RDS instance
+        awsRegion: ""
+        # IAM role ARN to assume for database access
+        iamRoleARN: ""
+        # Audience expected by the OIDC provider in AWS
+        audience: ""
+      # Maximum number of open connections in the pool per Connect instance.
+      # Without RDS Proxy: total DB connections = maxOpenConns × number of Connect replicas,
+      # which must not exceed the RDS instance's max_connections limit.
+      # With RDS Proxy: excess connections queue at the proxy, but keeping this reasonable (e.g. 10-25) is still recommended.
+      maxOpenConns: 95
+      # Maximum time a connection may be reused (Go duration string, e.g. "5m", "1h").
+      connMaxLifetime: "5m"
+      # Maximum time a connection may be idle before being closed (Go duration string, e.g. "1m").
+      connMaxIdleTime: "1m"
   # Expected audience from OIDC token from Cofide SPIRE server in workload clusters.
   connectPSATAudience: ""
   # Trust domain of in-cluster SPIRE server.


### PR DESCRIPTION
Adds support for configuring RDS as a backend for the datastore of the Connect API.

Depends on https://github.com/cofide/cofide-connect/pull/1974