### PR TITLE
docs(cofide-credex); use cofide namespace, use RSA for key generation

### DIFF
--- a/charts/cofide-credex/Chart.yaml
+++ b/charts/cofide-credex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cofide-credex
 description: Helm chart to deploy Cofide Credex
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "v0.13.0"
 maintainers:
   - name: Cofide

--- a/charts/cofide-credex/README.md
+++ b/charts/cofide-credex/README.md
@@ -11,10 +11,10 @@ A Helm chart for deploying Cofide Credex - an OAuth 2.0 Authorization Server (AS
 
 When the local signer is in use (the default), a Kubernetes Secret named `oauth-private-key` must exist in the release namespace **before installation**. It should contain the OAuth AS private key at the key `private-key.pem`.
 
-Generate an EC P-256 private key and create the Secret:
+Generate an RSA private key and create the Secret:
 
 ```bash
-openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out private-key.pem
+openssl genrsa -out private-key.pem 3072
 
 kubectl create secret generic oauth-private-key \
   --from-file=private-key.pem=private-key.pem

--- a/charts/cofide-credex/README.md
+++ b/charts/cofide-credex/README.md
@@ -17,6 +17,7 @@ Generate an RSA private key and create the Secret:
 openssl genrsa -out private-key.pem 3072
 
 kubectl create secret generic oauth-private-key \
+  --namespace cofide \
   --from-file=private-key.pem=private-key.pem
 ```
 
@@ -28,6 +29,7 @@ When the local signer is not in use (`credex.signing.method=spire` and `local` i
 
 ```bash
 helm install cofide-credex cofide/cofide-credex \
+  --namespace cofide \
   --set credex.issuerURL=https://credex.example.org \
   --set credex.connectURL=connect.example.org:443 \
   --set credex.connectTrustDomain=example.org


### PR DESCRIPTION
- **docs(cofide-credex): fix private key generation command to use RSA 3072**
    The README incorrectly suggested generating an EC P-256 key, but Credex
    only supports RSA for the local signer.
- **docs(cofide-credex): use cofide namespace in install example**
