### PR TITLE
Remove legacy audit events config

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.0
+version: 0.18.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/templates/configmap.yaml
+++ b/charts/cofide-connect/templates/configmap.yaml
@@ -100,7 +100,6 @@ data:
             claim_value: {{ .group.claimValue | quote }}
           {{- end }}
       {{- end }}
-    record_audit_events: {{ .Values.connect.recordAuditEvents | toString }}
     audit:
       sinks:
         connect_datastore:

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -406,10 +406,6 @@
           },
           "required": ["version", "roleBindings"]
         },
-        "recordAuditEvents": {
-          "type": "boolean",
-          "description": "Whether audit events should be recorded within Connect. If enabled all operations within Connect that change state (e.g. create/update/delete APIs, node attestation/deletion, workload creation/deletion) will be recorded."
-        },
         "audit": {
           "type": "object",
           "additionalProperties": false,
@@ -499,7 +495,6 @@
         "telemetryEnabled",
         "authzPolicyEngine",
         "initialRBAC",
-        "recordAuditEvents",
         "audit",
         "extraEnv"
       ]

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -145,9 +145,6 @@ connect:
     #    user:
     #      subject: clusterAadmin@example.com
     roleBindings: []
-  # Whether audit events should be recorded within Connect. If enabled all operations within Connect that change state (e.g. create/update/delete APIs, node attestation/deletion, workload creation/deletion) will be recorded.
-  # DEPRECATED: This flag is deprecated and will be removed in a future release. Use the `audit` configuration block instead.
-  recordAuditEvents: false
   # Audit configured audit event recording and the sinks events are sent to.
   audit:
     sinks:


### PR DESCRIPTION
We now have fine-grained control for audit events, this old config confuses things.