### PR TITLE
Fix values schema for extra env

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.0
+version: 0.18.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -447,36 +447,25 @@
           "description": "Additional environment variables to pass to the connect api binary.",
           "items": {
             "type": "object",
-            "allOf": [
-              {
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Environment variable name"
-                  }
-                },
-                "required": ["name"]
-              }
-            ],
-            "oneOf": [
-              {
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "Simple string value to be set as environment variable"
-                  }
-                },
-                "required": ["value"]
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Environment variable name"
               },
-              {
-                "properties": {
-                  "valueFrom": {
-                    "type": "object",
-                    "description": "Source of environment value as defined in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#envvarsource-v1-core"
-                  }
-                },
-                "required": ["valueFrom"]
+              "value": {
+                "type": "string",
+                "description": "Simple string value to be set as environment variable"
+              },
+              "valueFrom": {
+                "type": "object",
+                "description": "Source of environment value as defined in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#envvarsource-v1-core"
               }
+            },
+            "required": ["name"],
+            "oneOf": [
+              { "required": ["value"] },
+              { "required": ["valueFrom"] }
             ]
           }
         }

--- a/charts/cofide-credex/Chart.yaml
+++ b/charts/cofide-credex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cofide-credex
 description: Helm chart to deploy Cofide Credex
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "v0.13.0"
 maintainers:
   - name: Cofide

--- a/charts/cofide-credex/values.schema.json
+++ b/charts/cofide-credex/values.schema.json
@@ -202,36 +202,24 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "allOf": [
-              {
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Environment variable name."
-                  }
-                },
-                "required": ["name"]
-              }
-            ],
-            "oneOf": [
-              {
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "Simple string value for the environment variable."
-                  }
-                },
-                "required": ["value"]
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Environment variable name."
               },
-              {
-                "properties": {
-                  "valueFrom": {
-                    "type": "object",
-                    "description": "Source of the environment variable value, as defined in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#envvarsource-v1-core."
-                  }
-                },
-                "required": ["valueFrom"]
+              "value": {
+                "type": "string",
+                "description": "Simple string value for the environment variable."
+              },
+              "valueFrom": {
+                "type": "object",
+                "description": "Source of the environment variable value, as defined in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#envvarsource-v1-core."
               }
+            },
+            "required": ["name"],
+            "oneOf": [
+              { "required": ["value"] },
+              { "required": ["valueFrom"] }
             ]
           }
         }


### PR DESCRIPTION
Blocked by https://github.com/cofide/helm-charts/pull/123 (both bump chart version)

`additionalProperties: false` and `oneOf` are fiddly to use together in json-schema. The current version is resulting in the `oneOf` only seeing the `value` or `valueFrom` when it evaluates `additionalProperties` - so the presence of the `name` field is rejected.