### PR TITLE
Add use path style to chart config

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.1
+version: 0.19.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/templates/configmap.yaml
+++ b/charts/cofide-connect/templates/configmap.yaml
@@ -15,6 +15,7 @@ data:
       s3:
         enabled: {{ .enabled }}
         bucket: {{ .bucket }}
+        use_path_style: {{ .usePathStyle }}
         {{- with .oidc }}
         oidc:
           enabled: {{ .enabled }}

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -70,6 +70,10 @@
                       "type": "string",
                       "description": "Name of bucket to use as trust bundle store."
                     },
+                    "usePathStyle": {
+                      "type": "boolean",
+                      "description": "Determines if path-style addressing is used to access S3 buckets (if false, virtual-hosted-style is used)."
+                    },
                     "oidc": {
                       "type": "object",
                       "additionalProperties": false,
@@ -100,7 +104,7 @@
                       ]
                     }
                   },
-                  "required": ["enabled", "bucket", "oidc"]
+                  "required": ["enabled", "bucket", "usePathStyle", "oidc"]
                 }
               }
             },

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -39,6 +39,8 @@ connect:
       enabled: true
       # Name of bucket to use as trust bundle store.
       bucket: ""
+      # Determines if path-style addressing is used to access S3 buckets (if false, virtual-hosted-style is used).
+      usePathStyle: false
       # Configuration to use OIDC to access S3, exchanging the Connect server's SVID for AWS credentials.
       oidc:
         # True to use OIDC with the server's SVID to get temporary credentials to access S3 using OIDC, otherwise the AWS credentials will be sourced from the environment.


### PR DESCRIPTION
This is the remaining piece of config for Connect still only exposed through an env var before this change.

This unblocks the config simplification in https://github.com/cofide/cofide-connect/pull/1979.