### PR TITLE
Envoy config to support more authorisation servers

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.19.0
+version: 0.19.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -441,6 +441,13 @@ data:
                 tls_params:
                   tls_minimum_protocol_version: TLSv1_2
                   tls_maximum_protocol_version: TLSv1_3
+                validation_context:
+                  trusted_ca:
+                    filename: /etc/ssl/certs/ca-certificates.crt
+                  match_typed_subject_alt_names:
+                    - san_type: DNS
+                      matcher:
+                        exact: {{ (urlParse .Values.envoy.auth.jwksUri).host | splitList ":" | first }}
           {{- end }}
     admin:
       access_log_path: /dev/stdout

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -439,7 +439,7 @@ data:
               sni: {{ (urlParse .Values.envoy.auth.jwksUri).host }}
               common_tls_context:
                 tls_params:
-                  tls_minimum_protocol_version: TLSv1_3
+                  tls_minimum_protocol_version: TLSv1_2
                   tls_maximum_protocol_version: TLSv1_3
           {{- end }}
     admin:


### PR DESCRIPTION
- `validation_context` with system CA bundle: Explicitly configures TLS certificate verification for the JWKS cluster. A security improvement: without it, Envoy is not verifying the server's certificate at all, leaving the JWKS fetch open to MITM.
- `tls_minimum_protocol_version:  TLSv1_2`: Allows TLS 1.2 as the minimum for the JWKS cluster. Required because some auth servers (e.g. Okta's custom auth server) do not support TLS 1.3. Affects outbound JWKS fetch only - downstream client connections are unaffected.