### PR TITLE
Give chart deployers full control over Connect API hostnames/servernames

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.22.1
+version: 0.23.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/templates/NOTES.txt
+++ b/charts/cofide-connect/templates/NOTES.txt
@@ -1,4 +1,4 @@
 {{- if .Values.connect.urlBase }}
 WARNING: connect.urlBase is deprecated and will be removed in a future release.
-  Set connect.apiHostname, connect.mtlsServerName, and connect.xdsServerName explicitly instead.
+  Set connect.apiAddress, connect.mtlsServerName, and connect.xdsServerName explicitly instead.
 {{- end }}

--- a/charts/cofide-connect/templates/NOTES.txt
+++ b/charts/cofide-connect/templates/NOTES.txt
@@ -1,4 +1,4 @@
 {{- if .Values.connect.urlBase }}
 WARNING: connect.urlBase is deprecated and will be removed in a future release.
-  Set connect.apiHostname, connect.mtlsHostname, and connect.xdsHostname explicitly instead.
+  Set connect.apiHostname, connect.mtlsServerName, and connect.xdsServerName explicitly instead.
 {{- end }}

--- a/charts/cofide-connect/templates/NOTES.txt
+++ b/charts/cofide-connect/templates/NOTES.txt
@@ -1,0 +1,4 @@
+{{- if .Values.connect.urlBase }}
+WARNING: connect.urlBase is deprecated and will be removed in a future release.
+  Set connect.apiHostname, connect.mtlsHostname, and connect.xdsHostname explicitly instead.
+{{- end }}

--- a/charts/cofide-connect/templates/_helpers.tpl
+++ b/charts/cofide-connect/templates/_helpers.tpl
@@ -76,9 +76,9 @@ connect.{{ .Values.connect.urlBase }}
 TLS SNI for the TLS API endpoint. Defaults to apiAddress with any port stripped. Used only for
 Envoy's filter_chain_match - there is no HTTP-layer use of this value.
 */}}
-{{- define "cofide-connect.apiServername" -}}
-{{- if .Values.connect.apiServername -}}
-{{- .Values.connect.apiServername -}}
+{{- define "cofide-connect.apiServerName" -}}
+{{- if .Values.connect.apiServerName -}}
+{{- .Values.connect.apiServerName -}}
 {{- else -}}
 {{- regexReplaceAll ":[0-9]+$" (include "cofide-connect.apiAddress" .) "" -}}
 {{- end -}}

--- a/charts/cofide-connect/templates/_helpers.tpl
+++ b/charts/cofide-connect/templates/_helpers.tpl
@@ -62,7 +62,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Address (hostname, optionally with a port) for the JWT API endpoint (connect.<urlBase> by default).
+Address (hostname, optionally with a port) for the TLS API endpoint (connect.<urlBase> by default).
 */}}
 {{- define "cofide-connect.apiAddress" -}}
 {{- if .Values.connect.apiAddress -}}

--- a/charts/cofide-connect/templates/_helpers.tpl
+++ b/charts/cofide-connect/templates/_helpers.tpl
@@ -61,10 +61,43 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/*
+Hostname for the JWT API endpoint (connect.<urlBase> by default).
+*/}}
+{{- define "cofide-connect.apiHostname" -}}
+{{- if .Values.connect.apiHostname -}}
+{{- .Values.connect.apiHostname -}}
+{{- else -}}
+connect.{{ .Values.connect.urlBase }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Hostname for the SPIFFE mTLS endpoint (cofide-agent.<urlBase> by default).
+*/}}
+{{- define "cofide-connect.mtlsHostname" -}}
+{{- if .Values.connect.mtlsHostname -}}
+{{- .Values.connect.mtlsHostname -}}
+{{- else -}}
+cofide-agent.{{ .Values.connect.urlBase }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Hostname for the XDS/ADS endpoint (xds.<urlBase> by default).
+*/}}
+{{- define "cofide-connect.xdsHostname" -}}
+{{- if .Values.connect.xdsHostname -}}
+{{- .Values.connect.xdsHostname -}}
+{{- else -}}
+xds.{{ .Values.connect.urlBase }}
+{{- end -}}
+{{- end }}
+
 {{- define "cofide-connect.envoy.auth.audiences" -}}
 {{- if gt (len .Values.envoy.auth.audiences) 0 }}
 {{- toYaml .Values.envoy.auth.audiences }}
 {{- else -}}
-- https://connect.{{ .Values.connect.urlBase }}
+- https://{{ include "cofide-connect.apiHostname" . }}
 {{- end }}
 {{- end }}

--- a/charts/cofide-connect/templates/_helpers.tpl
+++ b/charts/cofide-connect/templates/_helpers.tpl
@@ -73,14 +73,14 @@ connect.{{ .Values.connect.urlBase }}
 {{- end }}
 
 {{/*
-TLS SNI for the SPIFFE mTLS endpoint (cofide-agent.<urlBase> by default). Used only for Envoy's
+TLS SNI for the SPIFFE mTLS endpoint (connect-agent.<urlBase> by default). Used only for Envoy's
 filter_chain_match - there is no HTTP-layer use of this value.
 */}}
 {{- define "cofide-connect.mtlsServerName" -}}
 {{- if .Values.connect.mtlsServerName -}}
 {{- .Values.connect.mtlsServerName -}}
 {{- else -}}
-cofide-agent.{{ .Values.connect.urlBase }}
+connect-agent.{{ .Values.connect.urlBase }}
 {{- end -}}
 {{- end }}
 

--- a/charts/cofide-connect/templates/_helpers.tpl
+++ b/charts/cofide-connect/templates/_helpers.tpl
@@ -73,22 +73,24 @@ connect.{{ .Values.connect.urlBase }}
 {{- end }}
 
 {{/*
-Hostname for the SPIFFE mTLS endpoint (cofide-agent.<urlBase> by default).
+TLS SNI for the SPIFFE mTLS endpoint (cofide-agent.<urlBase> by default). Used only for Envoy's
+filter_chain_match - there is no HTTP-layer use of this value.
 */}}
-{{- define "cofide-connect.mtlsHostname" -}}
-{{- if .Values.connect.mtlsHostname -}}
-{{- .Values.connect.mtlsHostname -}}
+{{- define "cofide-connect.mtlsServerName" -}}
+{{- if .Values.connect.mtlsServerName -}}
+{{- .Values.connect.mtlsServerName -}}
 {{- else -}}
 cofide-agent.{{ .Values.connect.urlBase }}
 {{- end -}}
 {{- end }}
 
 {{/*
-Hostname for the XDS/ADS endpoint (xds.<urlBase> by default).
+TLS SNI for the XDS/ADS endpoint (xds.<urlBase> by default). Used only for Envoy's
+filter_chain_match - there is no HTTP-layer use of this value.
 */}}
-{{- define "cofide-connect.xdsHostname" -}}
-{{- if .Values.connect.xdsHostname -}}
-{{- .Values.connect.xdsHostname -}}
+{{- define "cofide-connect.xdsServerName" -}}
+{{- if .Values.connect.xdsServerName -}}
+{{- .Values.connect.xdsServerName -}}
 {{- else -}}
 xds.{{ .Values.connect.urlBase }}
 {{- end -}}
@@ -99,5 +101,8 @@ xds.{{ .Values.connect.urlBase }}
 {{- toYaml .Values.envoy.auth.audiences }}
 {{- else -}}
 - https://{{ include "cofide-connect.apiHostname" . }}
+{{- range .Values.connect.apiExtraHostnames }}
+- https://{{ . }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/cofide-connect/templates/_helpers.tpl
+++ b/charts/cofide-connect/templates/_helpers.tpl
@@ -73,7 +73,7 @@ connect.{{ .Values.connect.urlBase }}
 {{- end }}
 
 {{/*
-TLS SNI for the JWT API endpoint. Defaults to apiAddress with any port stripped. Used only for
+TLS SNI for the TLS API endpoint. Defaults to apiAddress with any port stripped. Used only for
 Envoy's filter_chain_match - there is no HTTP-layer use of this value.
 */}}
 {{- define "cofide-connect.apiServername" -}}

--- a/charts/cofide-connect/templates/_helpers.tpl
+++ b/charts/cofide-connect/templates/_helpers.tpl
@@ -113,8 +113,8 @@ xds.{{ .Values.connect.urlBase }}
 {{- toYaml .Values.envoy.auth.audiences }}
 {{- else -}}
 - https://{{ include "cofide-connect.apiAddress" . }}
-{{- range .Values.connect.apiExtraHostnames }}
-- https://{{ . }}
+{{- range .Values.connect.apiExtraEndpoints }}
+- https://{{ .address }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/cofide-connect/templates/_helpers.tpl
+++ b/charts/cofide-connect/templates/_helpers.tpl
@@ -62,13 +62,25 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Hostname for the JWT API endpoint (connect.<urlBase> by default).
+Address (hostname, optionally with a port) for the JWT API endpoint (connect.<urlBase> by default).
 */}}
-{{- define "cofide-connect.apiHostname" -}}
-{{- if .Values.connect.apiHostname -}}
-{{- .Values.connect.apiHostname -}}
+{{- define "cofide-connect.apiAddress" -}}
+{{- if .Values.connect.apiAddress -}}
+{{- .Values.connect.apiAddress -}}
 {{- else -}}
 connect.{{ .Values.connect.urlBase }}
+{{- end -}}
+{{- end }}
+
+{{/*
+TLS SNI for the JWT API endpoint. Defaults to apiAddress with any port stripped. Used only for
+Envoy's filter_chain_match - there is no HTTP-layer use of this value.
+*/}}
+{{- define "cofide-connect.apiServername" -}}
+{{- if .Values.connect.apiServername -}}
+{{- .Values.connect.apiServername -}}
+{{- else -}}
+{{- regexReplaceAll ":[0-9]+$" (include "cofide-connect.apiAddress" .) "" -}}
 {{- end -}}
 {{- end }}
 
@@ -100,7 +112,7 @@ xds.{{ .Values.connect.urlBase }}
 {{- if gt (len .Values.envoy.auth.audiences) 0 }}
 {{- toYaml .Values.envoy.auth.audiences }}
 {{- else -}}
-- https://{{ include "cofide-connect.apiHostname" . }}
+- https://{{ include "cofide-connect.apiAddress" . }}
 {{- range .Values.connect.apiExtraHostnames }}
 - https://{{ . }}
 {{- end }}

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -63,7 +63,7 @@ data:
                 application_protocols:
                   - h2
                 server_names:
-                  - xds.{{ .Values.connect.urlBase }}
+                  - {{ include "cofide-connect.xdsHostname" . }}
               transport_socket:
                 name: envoy.transport_sockets.tls
                 typed_config:
@@ -135,7 +135,7 @@ data:
                   - h2
                   - http/1.1
                 server_names:
-                  - connect.{{ .Values.connect.urlBase }}
+                  - {{ include "cofide-connect.apiHostname" . }}
               transport_socket:
                 name: envoy.transport_sockets.tls
                 typed_config:
@@ -191,7 +191,7 @@ data:
                                 body:
                                   inline_string: |
                                     {
-                                      "resource": "https://connect.{{ .Values.connect.urlBase }}",
+                                      "resource": "https://{{ include "cofide-connect.apiHostname" . }}",
                                       "authorization_servers": ["{{ .Values.envoy.auth.issuer }}"],
                                       "scopes_supported": {{ .Values.envoy.auth.scopesSupported | toJson }},
                                       "bearer_methods_supported": ["header"]
@@ -279,10 +279,10 @@ data:
                               upstream_local_address: '%UPSTREAM_LOCAL_ADDRESS%'
                               grpc_status: '%GRPC_STATUS%'
                               requested_server_name: '%REQUESTED_SERVER_NAME%'
-            - name: connect_agent_api
+            - name: connect_mtls_api
               filter_chain_match:
                 server_names:
-                  - connect-agent.{{ .Values.connect.urlBase }}
+                  - {{ include "cofide-connect.mtlsHostname" . }}
               transport_socket:
                 name: envoy.transport_sockets.tls
                 typed_config:

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -190,14 +190,38 @@ data:
                               allow_credentials: true
                               max_age: "7200"
                           routes:
-                            # TODO: "resource" below always reflects connect.apiHostname, even when the
-                            # request came in on one of connect.apiExtraHostnames. Per RFC 9728, "resource"
-                            # is a single URI and clients are expected to validate it matches the URL they
-                            # fetched this document from - a request via an extra hostname currently gets a
-                            # mismatched value. Since Envoy's direct_response body is static, fixing this
-                            # properly means generating one route per hostname (matching on the :authority
-                            # header) each with its own body, looping over
-                            # [apiHostname] + apiExtraHostnames. Deferred until this is a real interop problem.
+                            # Per RFC 9728, "resource" must be the URI the client actually fetched this
+                            # document from, so we generate one route per accepted hostname, matching on
+                            # the :authority header, each with its own static body.
+                            {{- range $hostname := prepend $.Values.connect.apiExtraHostnames (include "cofide-connect.apiHostname" $) }}
+                            - match:
+                                path: "/.well-known/oauth-protected-resource"
+                                headers:
+                                  - name: ":authority"
+                                    string_match:
+                                      exact: {{ $hostname }}
+                              direct_response:
+                                status: 200
+                                body:
+                                  inline_string: |
+                                    {
+                                      "resource": "https://{{ $hostname }}",
+                                      "authorization_servers": ["{{ $.Values.envoy.auth.issuer }}"],
+                                      "scopes_supported": {{ $.Values.envoy.auth.scopesSupported | toJson }},
+                                      "bearer_methods_supported": ["header"]
+                                    }
+                              response_headers_to_add:
+                              - header:
+                                  key: "content-type"
+                                  value: "application/json"
+                              # Explicitly disable JWT auth for this public discovery endpoint
+                              typed_per_filter_config:
+                                envoy.filters.http.jwt_authn:
+                                  "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+                                  disabled: true
+                            {{- end }}
+                            # Fallback for requests whose :authority doesn't match any accepted hostname
+                            # (e.g. mismatched SNI/Host). Keeps the endpoint responding rather than 404ing.
                             - match:
                                 path: "/.well-known/oauth-protected-resource"
                               direct_response:

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -191,25 +191,30 @@ data:
                               max_age: "7200"
                           routes:
                             # Per RFC 9728, "resource" must be the URI the client actually fetched this
-                            # document from, so we generate one route per accepted hostname, matching on
-                            # the :authority header, each with its own static body.
+                            # document from, so we generate one route per accepted address, matching on
+                            # the :authority header, each with its own static body. This is an exact
+                            # match, so addresses should normally be given without a port (443 is the
+                            # default for https and most clients omit it from :authority/Host). If some
+                            # client insists on sending the port explicitly anyway, add a second address
+                            # entry with ":443" appended rather than putting the port on apiAddress
+                            # itself - the only side effect is a redundant SNI entry and OAuth audience.
                             {{- $apiAddresses := list (include "cofide-connect.apiAddress" $) }}
                             {{- range $.Values.connect.apiExtraEndpoints }}
                             {{- $apiAddresses = append $apiAddresses .address }}
                             {{- end }}
-                            {{- range $hostname := $apiAddresses }}
+                            {{- range $address := $apiAddresses }}
                             - match:
                                 path: "/.well-known/oauth-protected-resource"
                                 headers:
                                   - name: ":authority"
                                     string_match:
-                                      exact: {{ $hostname }}
+                                      exact: {{ $address }}
                               direct_response:
                                 status: 200
                                 body:
                                   inline_string: |
                                     {
-                                      "resource": "https://{{ $hostname }}",
+                                      "resource": "https://{{ $address }}",
                                       "authorization_servers": ["{{ $.Values.envoy.auth.issuer }}"],
                                       "scopes_supported": {{ $.Values.envoy.auth.scopesSupported | toJson }},
                                       "bearer_methods_supported": ["header"]
@@ -224,7 +229,7 @@ data:
                                   "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
                                   disabled: true
                             {{- end }}
-                            # Fallback for requests whose :authority doesn't match any accepted hostname
+                            # Fallback for requests whose :authority doesn't match any accepted address
                             # (e.g. mismatched SNI/Host). Keeps the endpoint responding rather than 404ing.
                             - match:
                                 path: "/.well-known/oauth-protected-resource"

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -138,7 +138,7 @@ data:
                   - h2
                   - http/1.1
                 server_names:
-                  - {{ include "cofide-connect.apiHostname" . }}
+                  - {{ include "cofide-connect.apiServername" . }}
                   {{- range .Values.connect.apiExtraHostnames }}
                   - {{ . }}
                   {{- end }}
@@ -193,7 +193,7 @@ data:
                             # Per RFC 9728, "resource" must be the URI the client actually fetched this
                             # document from, so we generate one route per accepted hostname, matching on
                             # the :authority header, each with its own static body.
-                            {{- range $hostname := prepend $.Values.connect.apiExtraHostnames (include "cofide-connect.apiHostname" $) }}
+                            {{- range $hostname := prepend $.Values.connect.apiExtraHostnames (include "cofide-connect.apiAddress" $) }}
                             - match:
                                 path: "/.well-known/oauth-protected-resource"
                                 headers:
@@ -229,7 +229,7 @@ data:
                                 body:
                                   inline_string: |
                                     {
-                                      "resource": "https://{{ include "cofide-connect.apiHostname" . }}",
+                                      "resource": "https://{{ include "cofide-connect.apiAddress" . }}",
                                       "authorization_servers": ["{{ .Values.envoy.auth.issuer }}"],
                                       "scopes_supported": {{ .Values.envoy.auth.scopesSupported | toJson }},
                                       "bearer_methods_supported": ["header"]

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -139,8 +139,8 @@ data:
                   - http/1.1
                 server_names:
                   - {{ include "cofide-connect.apiServername" . }}
-                  {{- range .Values.connect.apiExtraHostnames }}
-                  - {{ . }}
+                  {{- range .Values.connect.apiExtraEndpoints }}
+                  - {{ if .servername }}{{ .servername }}{{ else }}{{ regexReplaceAll ":[0-9]+$" .address "" }}{{ end }}
                   {{- end }}
               transport_socket:
                 name: envoy.transport_sockets.tls
@@ -193,7 +193,11 @@ data:
                             # Per RFC 9728, "resource" must be the URI the client actually fetched this
                             # document from, so we generate one route per accepted hostname, matching on
                             # the :authority header, each with its own static body.
-                            {{- range $hostname := prepend $.Values.connect.apiExtraHostnames (include "cofide-connect.apiAddress" $) }}
+                            {{- $apiAddresses := list (include "cofide-connect.apiAddress" $) }}
+                            {{- range $.Values.connect.apiExtraEndpoints }}
+                            {{- $apiAddresses = append $apiAddresses .address }}
+                            {{- end }}
+                            {{- range $hostname := $apiAddresses }}
                             - match:
                                 path: "/.well-known/oauth-protected-resource"
                                 headers:

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -63,7 +63,10 @@ data:
                 application_protocols:
                   - h2
                 server_names:
-                  - {{ include "cofide-connect.xdsHostname" . }}
+                  - {{ include "cofide-connect.xdsServerName" . }}
+                  {{- range .Values.connect.xdsExtraServerNames }}
+                  - {{ . }}
+                  {{- end }}
               transport_socket:
                 name: envoy.transport_sockets.tls
                 typed_config:
@@ -136,6 +139,9 @@ data:
                   - http/1.1
                 server_names:
                   - {{ include "cofide-connect.apiHostname" . }}
+                  {{- range .Values.connect.apiExtraHostnames }}
+                  - {{ . }}
+                  {{- end }}
               transport_socket:
                 name: envoy.transport_sockets.tls
                 typed_config:
@@ -184,6 +190,14 @@ data:
                               allow_credentials: true
                               max_age: "7200"
                           routes:
+                            # TODO: "resource" below always reflects connect.apiHostname, even when the
+                            # request came in on one of connect.apiExtraHostnames. Per RFC 9728, "resource"
+                            # is a single URI and clients are expected to validate it matches the URL they
+                            # fetched this document from - a request via an extra hostname currently gets a
+                            # mismatched value. Since Envoy's direct_response body is static, fixing this
+                            # properly means generating one route per hostname (matching on the :authority
+                            # header) each with its own body, looping over
+                            # [apiHostname] + apiExtraHostnames. Deferred until this is a real interop problem.
                             - match:
                                 path: "/.well-known/oauth-protected-resource"
                               direct_response:
@@ -282,7 +296,10 @@ data:
             - name: connect_mtls_api
               filter_chain_match:
                 server_names:
-                  - {{ include "cofide-connect.mtlsHostname" . }}
+                  - {{ include "cofide-connect.mtlsServerName" . }}
+                  {{- range .Values.connect.mtlsExtraServerNames }}
+                  - {{ . }}
+                  {{- end }}
               transport_socket:
                 name: envoy.transport_sockets.tls
                 typed_config:

--- a/charts/cofide-connect/templates/configmap-envoy.yaml
+++ b/charts/cofide-connect/templates/configmap-envoy.yaml
@@ -138,9 +138,9 @@ data:
                   - h2
                   - http/1.1
                 server_names:
-                  - {{ include "cofide-connect.apiServername" . }}
+                  - {{ include "cofide-connect.apiServerName" . }}
                   {{- range .Values.connect.apiExtraEndpoints }}
-                  - {{ if .servername }}{{ .servername }}{{ else }}{{ regexReplaceAll ":[0-9]+$" .address "" }}{{ end }}
+                  - {{ if .serverName }}{{ .serverName }}{{ else }}{{ regexReplaceAll ":[0-9]+$" .address "" }}{{ end }}
                   {{- end }}
               transport_socket:
                 name: envoy.transport_sockets.tls

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -30,7 +30,7 @@
             "properties": {
               "address": {
                 "type": "string",
-                "description": "Address (hostname, optionally with a port) for this additional JWT API endpoint. Used for the OAuth audience, oauth-protected-resource 'resource' value, and :authority/Host matching."
+                "description": "Address (hostname, optionally with a port) for this additional TLS API endpoint. Used for the OAuth audience, oauth-protected-resource 'resource' value, and :authority/Host matching."
               },
               "servername": {
                 "type": "string",

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -518,7 +518,6 @@
         }
       },
       "required": [
-        "urlBase",
         "allowedOrigins",
         "insecureServerAddress",
         "adsServerAddress",
@@ -533,6 +532,10 @@
         "initialRBAC",
         "audit",
         "extraEnv"
+      ],
+      "anyOf": [
+        { "required": ["urlBase"] },
+        { "required": ["apiHostname", "mtlsServerName", "xdsServerName"] }
       ]
     },
     "service": {

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -14,7 +14,7 @@
         },
         "apiAddress": {
           "type": "string",
-          "description": "Address (hostname, optionally with a port) for the JWT API endpoint. Defaults to connect.<urlBase>. Also used as the OAuth audience and oauth-protected-resource 'resource' value, so this is the real address clients use, not just a TLS SNI."
+          "description": "Address (hostname, optionally with a port) for the TLS API endpoint. Defaults to connect.<urlBase>. Also used as the OAuth audience and oauth-protected-resource 'resource' value, so this is the real address clients use, not just a TLS SNI."
         },
         "apiServername": {
           "type": "string",

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -20,11 +20,23 @@
           "type": "string",
           "description": "TLS SNI for the JWT API endpoint. Defaults to apiAddress with any port stripped. Only used for Envoy's filter_chain_match."
         },
-        "apiExtraHostnames": {
+        "apiExtraEndpoints": {
           "type": "array",
-          "description": "Additional hostnames Envoy will accept for the JWT API endpoint, as SNIs and as :authority/Host values, alongside apiServername and apiAddress respectively.",
+          "description": "Additional endpoints Envoy will accept for the JWT API, alongside apiAddress/apiServername.",
           "items": {
-            "type": "string"
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["address"],
+            "properties": {
+              "address": {
+                "type": "string",
+                "description": "Address (hostname, optionally with a port) for this additional JWT API endpoint. Used for the OAuth audience, oauth-protected-resource 'resource' value, and :authority/Host matching."
+              },
+              "servername": {
+                "type": "string",
+                "description": "TLS SNI Envoy matches for this endpoint. Defaults to address with any port stripped. Only used for Envoy's filter_chain_match."
+              }
+            }
           }
         },
         "mtlsServerName": {

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -18,7 +18,7 @@
         },
         "apiServerName": {
           "type": "string",
-          "description": "TLS SNI for the JWT API endpoint. Defaults to apiAddress with any port stripped. Only used for Envoy's filter_chain_match."
+          "description": "TLS SNI for the TLS API endpoint. Defaults to apiAddress with any port stripped. Only used for Envoy's filter_chain_match."
         },
         "apiExtraEndpoints": {
           "type": "array",

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -10,19 +10,40 @@
       "properties": {
         "urlBase": {
           "type": "string",
-          "description": "Deprecated: use apiHostname, mtlsHostname, and xdsHostname instead. urlBase will be removed in a future release. Used to construct default endpoint hostnames when the explicit hostname values are not set."
+          "description": "Deprecated: use apiHostname, mtlsServerName, and xdsServerName instead. urlBase will be removed in a future release. Used to construct default endpoint hostnames/SNIs when the explicit values are not set."
         },
         "apiHostname": {
           "type": "string",
-          "description": "Hostname for the JWT API endpoint. Defaults to connect.<urlBase>."
+          "description": "Hostname for the JWT API endpoint. Defaults to connect.<urlBase>. Also used as the OAuth audience and oauth-protected-resource 'resource' value, so this is a real hostname, not just a TLS SNI."
         },
-        "mtlsHostname": {
-          "type": "string",
-          "description": "Hostname for the SPIFFE mTLS endpoint. Defaults to cofide-agent.<urlBase>."
+        "apiExtraHostnames": {
+          "type": "array",
+          "description": "Additional SNI hostnames Envoy will accept for the JWT API endpoint, alongside apiHostname.",
+          "items": {
+            "type": "string"
+          }
         },
-        "xdsHostname": {
+        "mtlsServerName": {
           "type": "string",
-          "description": "Hostname for the XDS/ADS endpoint. Defaults to xds.<urlBase>."
+          "description": "TLS SNI for the SPIFFE mTLS endpoint. Defaults to cofide-agent.<urlBase>. Only used for Envoy's filter_chain_match."
+        },
+        "mtlsExtraServerNames": {
+          "type": "array",
+          "description": "Additional SNIs Envoy will accept for the SPIFFE mTLS endpoint, alongside mtlsServerName.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "xdsServerName": {
+          "type": "string",
+          "description": "TLS SNI for the XDS/ADS endpoint. Defaults to xds.<urlBase>. Only used for Envoy's filter_chain_match."
+        },
+        "xdsExtraServerNames": {
+          "type": "array",
+          "description": "Additional SNIs Envoy will accept for the XDS/ADS endpoint, alongside xdsServerName.",
+          "items": {
+            "type": "string"
+          }
         },
         "allowedOrigins": {
           "type": "array",

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -22,7 +22,7 @@
         },
         "apiExtraEndpoints": {
           "type": "array",
-          "description": "Additional endpoints Envoy will accept for the JWT API, alongside apiAddress/apiServername.",
+          "description": "Additional endpoints Envoy will accept for the TLS API, alongside apiAddress/apiServername.",
           "items": {
             "type": "object",
             "additionalProperties": false,

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -16,13 +16,13 @@
           "type": "string",
           "description": "Address (hostname, optionally with a port) for the TLS API endpoint. Defaults to connect.<urlBase>. Also used as the OAuth audience and oauth-protected-resource 'resource' value, so this is the real address clients use, not just a TLS SNI."
         },
-        "apiServername": {
+        "apiServerName": {
           "type": "string",
           "description": "TLS SNI for the JWT API endpoint. Defaults to apiAddress with any port stripped. Only used for Envoy's filter_chain_match."
         },
         "apiExtraEndpoints": {
           "type": "array",
-          "description": "Additional endpoints Envoy will accept for the TLS API, alongside apiAddress/apiServername.",
+          "description": "Additional endpoints Envoy will accept for the TLS API, alongside apiAddress/apiServerName.",
           "items": {
             "type": "object",
             "additionalProperties": false,
@@ -32,7 +32,7 @@
                 "type": "string",
                 "description": "Address (hostname, optionally with a port) for this additional TLS API endpoint. Used for the OAuth audience, oauth-protected-resource 'resource' value, and :authority/Host matching."
               },
-              "servername": {
+              "serverName": {
                 "type": "string",
                 "description": "TLS SNI Envoy matches for this endpoint. Defaults to address with any port stripped. Only used for Envoy's filter_chain_match."
               }

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -10,7 +10,19 @@
       "properties": {
         "urlBase": {
           "type": "string",
-          "description": "The base URL for the Connect service."
+          "description": "Deprecated: use apiHostname, mtlsHostname, and xdsHostname instead. urlBase will be removed in a future release. Used to construct default endpoint hostnames when the explicit hostname values are not set."
+        },
+        "apiHostname": {
+          "type": "string",
+          "description": "Hostname for the JWT API endpoint. Defaults to connect.<urlBase>."
+        },
+        "mtlsHostname": {
+          "type": "string",
+          "description": "Hostname for the SPIFFE mTLS endpoint. Defaults to cofide-agent.<urlBase>."
+        },
+        "xdsHostname": {
+          "type": "string",
+          "description": "Hostname for the XDS/ADS endpoint. Defaults to xds.<urlBase>."
         },
         "allowedOrigins": {
           "type": "array",

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -25,7 +25,7 @@
         },
         "mtlsServerName": {
           "type": "string",
-          "description": "TLS SNI for the SPIFFE mTLS endpoint. Defaults to cofide-agent.<urlBase>. Only used for Envoy's filter_chain_match."
+          "description": "TLS SNI for the SPIFFE mTLS endpoint. Defaults to connect-agent.<urlBase>. Only used for Envoy's filter_chain_match."
         },
         "mtlsExtraServerNames": {
           "type": "array",

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -10,15 +10,19 @@
       "properties": {
         "urlBase": {
           "type": "string",
-          "description": "Deprecated: use apiHostname, mtlsServerName, and xdsServerName instead. urlBase will be removed in a future release. Used to construct default endpoint hostnames/SNIs when the explicit values are not set."
+          "description": "Deprecated: use apiAddress, mtlsServerName, and xdsServerName instead. urlBase will be removed in a future release. Used to construct default endpoint hostnames/SNIs when the explicit values are not set."
         },
-        "apiHostname": {
+        "apiAddress": {
           "type": "string",
-          "description": "Hostname for the JWT API endpoint. Defaults to connect.<urlBase>. Also used as the OAuth audience and oauth-protected-resource 'resource' value, so this is a real hostname, not just a TLS SNI."
+          "description": "Address (hostname, optionally with a port) for the JWT API endpoint. Defaults to connect.<urlBase>. Also used as the OAuth audience and oauth-protected-resource 'resource' value, so this is the real address clients use, not just a TLS SNI."
+        },
+        "apiServername": {
+          "type": "string",
+          "description": "TLS SNI for the JWT API endpoint. Defaults to apiAddress with any port stripped. Only used for Envoy's filter_chain_match."
         },
         "apiExtraHostnames": {
           "type": "array",
-          "description": "Additional SNI hostnames Envoy will accept for the JWT API endpoint, alongside apiHostname.",
+          "description": "Additional hostnames Envoy will accept for the JWT API endpoint, as SNIs and as :authority/Host values, alongside apiServername and apiAddress respectively.",
           "items": {
             "type": "string"
           }
@@ -535,7 +539,7 @@
       ],
       "anyOf": [
         { "required": ["urlBase"] },
-        { "required": ["apiHostname", "mtlsServerName", "xdsServerName"] }
+        { "required": ["apiAddress", "mtlsServerName", "xdsServerName"] }
       ]
     },
     "service": {

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -18,7 +18,7 @@ connect:
   # Used to construct default endpoint hostnames (connect.<urlBase>, connect-agent.<urlBase>, xds.<urlBase>) when the explicit hostname/SNI values are not set.
   urlBase: ""
   # Address (hostname, optionally with a port, e.g. "connect.example.com" or "connect.example.com:8443")
-  # for the JWT API endpoint. Defaults to connect.<urlBase>. Also used as the OAuth audience and the
+  # for the TLS API endpoint. Defaults to connect.<urlBase>. Also used as the OAuth audience and the
   # "resource" value in the oauth-protected-resource metadata, so this is the real address clients use,
   # not just a TLS SNI.
   apiAddress: ""

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -22,11 +22,11 @@ connect:
   # "resource" value in the oauth-protected-resource metadata, so this is the real address clients use,
   # not just a TLS SNI.
   apiAddress: ""
-  # TLS SNI for the JWT API endpoint. Defaults to apiAddress with any port stripped. Only needs to be
+  # TLS SNI for the TLS API endpoint. Defaults to apiAddress with any port stripped. Only needs to be
   # set explicitly if the SNI presented by clients differs from apiAddress's hostname (e.g. behind a
   # proxy that terminates a different SNI). Only used for Envoy's filter_chain_match.
   apiServerName: ""
-  # Additional endpoints Envoy will accept for the JWT API, alongside apiAddress/apiServerName.
+  # Additional endpoints Envoy will accept for the TLS API, alongside apiAddress/apiServerName.
   # Useful when the same Connect instance is reachable under more than one public hostname. Each entry
   # is an object with:
   #  address: (required) hostname, optionally with a port, used for the OAuth audience, the
@@ -53,7 +53,7 @@ connect:
   # Allowed origins for CORS requests.
   allowedOrigins: []
   # Host and port the API server listens on internally.
-  # This port is not exposed on the pod itself, it is the port the envoy-sidecar sends requests to for the JWT API and SPIFFE mTLS SNI hostname matches.
+  # This port is not exposed on the pod itself, it is the port the envoy-sidecar sends requests to for the TLS API and SPIFFE mTLS SNI hostname matches.
   # Healthchecks are also served on this port.
   insecureServerAddress:
     host: ""
@@ -214,7 +214,7 @@ envoy:
     # JWKS URI of the IdP in use. Only http and https schemes are supported.
     jwksUri: ""
     # Name of secret in the same namespace containing the TLS private key and cert to be used with the domain Connect is exposed on.
-    # This certificate must be valid for the JWT API hostname (connect.<urlBase>, or apiAddress if set). The mTLS and XDS endpoints use SPIFFE SVIDs obtained from SPIRE, not this secret.
+    # This certificate must be valid for the TLS API hostname (connect.<urlBase>, or apiAddress if set). The mTLS and XDS endpoints use SPIFFE SVIDs obtained from SPIRE, not this secret.
     tlsSecretName: ""
     # Audiences set in tokens from the IdP. If empty, defaults to `["https://connect.{{ .Values.connect.urlBase }}"]`
     audiences: []

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -25,20 +25,20 @@ connect:
   # TLS SNI for the JWT API endpoint. Defaults to apiAddress with any port stripped. Only needs to be
   # set explicitly if the SNI presented by clients differs from apiAddress's hostname (e.g. behind a
   # proxy that terminates a different SNI). Only used for Envoy's filter_chain_match.
-  apiServername: ""
-  # Additional endpoints Envoy will accept for the JWT API, alongside apiAddress/apiServername.
+  apiServerName: ""
+  # Additional endpoints Envoy will accept for the JWT API, alongside apiAddress/apiServerName.
   # Useful when the same Connect instance is reachable under more than one public hostname. Each entry
   # is an object with:
   #  address: (required) hostname, optionally with a port, used for the OAuth audience, the
   #    oauth-protected-resource "resource" value, and :authority/Host matching - a real address, not
   #    just a TLS SNI.
-  #  servername: (optional) TLS SNI Envoy matches for this endpoint. Defaults to address with any
+  #  serverName: (optional) TLS SNI Envoy matches for this endpoint. Defaults to address with any
   #    port stripped. Only used for Envoy's filter_chain_match.
   # For example:
   #  apiExtraEndpoints:
   #  - address: connect2.example.com:8443
   #  - address: connect3.example.com
-  #    servername: connect3-sni.example.com
+  #    serverName: connect3-sni.example.com
   apiExtraEndpoints: []
   # TLS SNI for the SPIFFE mTLS endpoint. Defaults to connect-agent.<urlBase>. Only used for
   # Envoy's filter_chain_match - there is no HTTP-layer use of this value.

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -14,18 +14,25 @@ image:
   tag: ""
 
 connect:
-  # Base URL for envoy.
+  # Deprecated: use apiHostname, mtlsHostname, and xdsHostname instead. urlBase will be removed in a future release.
+  # Used to construct default endpoint hostnames (connect.<urlBase>, connect-mtls.<urlBase>, xds.<urlBase>) when the explicit hostname values are not set.
   urlBase: ""
+  # Hostname for the JWT API endpoint. Defaults to connect.<urlBase>.
+  apiHostname: ""
+  # Hostname for the SPIFFE mTLS endpoint. Defaults to cofide-agent.<urlBase>.
+  mtlsHostname: ""
+  # Hostname for the XDS/ADS endpoint. Defaults to xds.<urlBase>.
+  xdsHostname: ""
   # Allowed origins for CORS requests.
   allowedOrigins: []
   # Host and port the API server listens on internally.
-  # This port is not exposed on the pod itself, it is the port the envoy-sidecar sends requests to for connect.{{ .Values.connect.urlBase }} and connect-agent.{{ .Values.connect.urlBase }} SNI hostname matches.
+  # This port is not exposed on the pod itself, it is the port the envoy-sidecar sends requests to for the JWT API and SPIFFE mTLS SNI hostname matches.
   # Healthchecks are also served on this port.
   insecureServerAddress:
     host: ""
     port: 51106
   # Host and port the Aggregated Discovery Service listens on internally (used by workload clusters to get federated services).
-  # This port is not exposed on the pod itself, it is the port the envoy-sidecar sends requests to for xds.{{ .Values.connect.urlBase }} SNI hostname matches.
+  # This port is not exposed on the pod itself, it is the port the envoy-sidecar sends requests to for the XDS/ADS SNI hostname match.
   adsServerAddress:
     host: ""
     port: 18000
@@ -180,7 +187,7 @@ envoy:
     # JWKS URI of the IdP in use. Only http and https schemes are supported.
     jwksUri: ""
     # Name of secret in the same namespace containing the TLS private key and cert to be used with the domain Connect is exposed on.
-    # This certificate must be valid for connect.{{ .Values.connect.urlBase }}, connect-agent.{{ .Values.connect.urlBase }} and xds.{{ .Values.connect.urlBase }}.
+    # This certificate must be valid for the JWT API hostname (connect.<urlBase>, or apiHostname if set). The mTLS and XDS endpoints use SPIFFE SVIDs obtained from SPIRE, not this secret.
     tlsSecretName: ""
     # Audiences set in tokens from the IdP. If empty, defaults to `["https://connect.{{ .Values.connect.urlBase }}"]`
     audiences: []

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -26,10 +26,20 @@ connect:
   # set explicitly if the SNI presented by clients differs from apiAddress's hostname (e.g. behind a
   # proxy that terminates a different SNI). Only used for Envoy's filter_chain_match.
   apiServername: ""
-  # Additional hostnames Envoy will accept for the JWT API endpoint, as SNIs and as :authority/Host
-  # values, alongside apiServername and apiAddress respectively. Useful when the same Connect
-  # instance is reachable under more than one public hostname.
-  apiExtraHostnames: []
+  # Additional endpoints Envoy will accept for the JWT API, alongside apiAddress/apiServername.
+  # Useful when the same Connect instance is reachable under more than one public hostname. Each entry
+  # is an object with:
+  #  address: (required) hostname, optionally with a port, used for the OAuth audience, the
+  #    oauth-protected-resource "resource" value, and :authority/Host matching - a real address, not
+  #    just a TLS SNI.
+  #  servername: (optional) TLS SNI Envoy matches for this endpoint. Defaults to address with any
+  #    port stripped. Only used for Envoy's filter_chain_match.
+  # For example:
+  #  apiExtraEndpoints:
+  #  - address: connect2.example.com:8443
+  #  - address: connect3.example.com
+  #    servername: connect3-sni.example.com
+  apiExtraEndpoints: []
   # TLS SNI for the SPIFFE mTLS endpoint. Defaults to connect-agent.<urlBase>. Only used for
   # Envoy's filter_chain_match - there is no HTTP-layer use of this value.
   mtlsServerName: ""

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -14,15 +14,21 @@ image:
   tag: ""
 
 connect:
-  # Deprecated: use apiHostname, mtlsServerName, and xdsServerName instead. urlBase will be removed in a future release.
+  # Deprecated: use apiAddress, mtlsServerName, and xdsServerName instead. urlBase will be removed in a future release.
   # Used to construct default endpoint hostnames (connect.<urlBase>, connect-agent.<urlBase>, xds.<urlBase>) when the explicit hostname/SNI values are not set.
   urlBase: ""
-  # Hostname for the JWT API endpoint. Defaults to connect.<urlBase>. Also used as the OAuth
-  # audience and the "resource" value in the oauth-protected-resource metadata, so this is a
-  # real hostname, not just a TLS SNI.
-  apiHostname: ""
-  # Additional SNI hostnames Envoy will accept for the JWT API endpoint, alongside apiHostname.
-  # Useful when the same Connect instance is reachable under more than one public hostname.
+  # Address (hostname, optionally with a port, e.g. "connect.example.com" or "connect.example.com:8443")
+  # for the JWT API endpoint. Defaults to connect.<urlBase>. Also used as the OAuth audience and the
+  # "resource" value in the oauth-protected-resource metadata, so this is the real address clients use,
+  # not just a TLS SNI.
+  apiAddress: ""
+  # TLS SNI for the JWT API endpoint. Defaults to apiAddress with any port stripped. Only needs to be
+  # set explicitly if the SNI presented by clients differs from apiAddress's hostname (e.g. behind a
+  # proxy that terminates a different SNI). Only used for Envoy's filter_chain_match.
+  apiServername: ""
+  # Additional hostnames Envoy will accept for the JWT API endpoint, as SNIs and as :authority/Host
+  # values, alongside apiServername and apiAddress respectively. Useful when the same Connect
+  # instance is reachable under more than one public hostname.
   apiExtraHostnames: []
   # TLS SNI for the SPIFFE mTLS endpoint. Defaults to connect-agent.<urlBase>. Only used for
   # Envoy's filter_chain_match - there is no HTTP-layer use of this value.
@@ -198,7 +204,7 @@ envoy:
     # JWKS URI of the IdP in use. Only http and https schemes are supported.
     jwksUri: ""
     # Name of secret in the same namespace containing the TLS private key and cert to be used with the domain Connect is exposed on.
-    # This certificate must be valid for the JWT API hostname (connect.<urlBase>, or apiHostname if set). The mTLS and XDS endpoints use SPIFFE SVIDs obtained from SPIRE, not this secret.
+    # This certificate must be valid for the JWT API hostname (connect.<urlBase>, or apiAddress if set). The mTLS and XDS endpoints use SPIFFE SVIDs obtained from SPIRE, not this secret.
     tlsSecretName: ""
     # Audiences set in tokens from the IdP. If empty, defaults to `["https://connect.{{ .Values.connect.urlBase }}"]`
     audiences: []

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -15,7 +15,7 @@ image:
 
 connect:
   # Deprecated: use apiHostname, mtlsServerName, and xdsServerName instead. urlBase will be removed in a future release.
-  # Used to construct default endpoint hostnames (connect.<urlBase>, cofide-agent.<urlBase>, xds.<urlBase>) when the explicit hostname/SNI values are not set.
+  # Used to construct default endpoint hostnames (connect.<urlBase>, connect-agent.<urlBase>, xds.<urlBase>) when the explicit hostname/SNI values are not set.
   urlBase: ""
   # Hostname for the JWT API endpoint. Defaults to connect.<urlBase>. Also used as the OAuth
   # audience and the "resource" value in the oauth-protected-resource metadata, so this is a
@@ -24,7 +24,7 @@ connect:
   # Additional SNI hostnames Envoy will accept for the JWT API endpoint, alongside apiHostname.
   # Useful when the same Connect instance is reachable under more than one public hostname.
   apiExtraHostnames: []
-  # TLS SNI for the SPIFFE mTLS endpoint. Defaults to cofide-agent.<urlBase>. Only used for
+  # TLS SNI for the SPIFFE mTLS endpoint. Defaults to connect-agent.<urlBase>. Only used for
   # Envoy's filter_chain_match - there is no HTTP-layer use of this value.
   mtlsServerName: ""
   # Additional SNIs Envoy will accept for the SPIFFE mTLS endpoint, alongside mtlsServerName.

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -14,15 +14,26 @@ image:
   tag: ""
 
 connect:
-  # Deprecated: use apiHostname, mtlsHostname, and xdsHostname instead. urlBase will be removed in a future release.
-  # Used to construct default endpoint hostnames (connect.<urlBase>, connect-mtls.<urlBase>, xds.<urlBase>) when the explicit hostname values are not set.
+  # Deprecated: use apiHostname, mtlsServerName, and xdsServerName instead. urlBase will be removed in a future release.
+  # Used to construct default endpoint hostnames (connect.<urlBase>, cofide-agent.<urlBase>, xds.<urlBase>) when the explicit hostname/SNI values are not set.
   urlBase: ""
-  # Hostname for the JWT API endpoint. Defaults to connect.<urlBase>.
+  # Hostname for the JWT API endpoint. Defaults to connect.<urlBase>. Also used as the OAuth
+  # audience and the "resource" value in the oauth-protected-resource metadata, so this is a
+  # real hostname, not just a TLS SNI.
   apiHostname: ""
-  # Hostname for the SPIFFE mTLS endpoint. Defaults to cofide-agent.<urlBase>.
-  mtlsHostname: ""
-  # Hostname for the XDS/ADS endpoint. Defaults to xds.<urlBase>.
-  xdsHostname: ""
+  # Additional SNI hostnames Envoy will accept for the JWT API endpoint, alongside apiHostname.
+  # Useful when the same Connect instance is reachable under more than one public hostname.
+  apiExtraHostnames: []
+  # TLS SNI for the SPIFFE mTLS endpoint. Defaults to cofide-agent.<urlBase>. Only used for
+  # Envoy's filter_chain_match - there is no HTTP-layer use of this value.
+  mtlsServerName: ""
+  # Additional SNIs Envoy will accept for the SPIFFE mTLS endpoint, alongside mtlsServerName.
+  mtlsExtraServerNames: []
+  # TLS SNI for the XDS/ADS endpoint. Defaults to xds.<urlBase>. Only used for Envoy's
+  # filter_chain_match - there is no HTTP-layer use of this value.
+  xdsServerName: ""
+  # Additional SNIs Envoy will accept for the XDS/ADS endpoint, alongside xdsServerName.
+  xdsExtraServerNames: []
   # Allowed origins for CORS requests.
   allowedOrigins: []
   # Host and port the API server listens on internally.


### PR DESCRIPTION
- Add `.connect.apiAddress`, `.connect.mtlsServerName` and `.connect.xdsServerName` to replace `.connect.urlBase`. This allows the chart deployer to be explicit about the how the JWT authenticated (with webPKI) API, SPIFFE mTLS authenticated API and xDS server are exposed instead of forcing them to use SNIs `connect.<urlBase>`, `connect-agent.<urlBase>` and `xds.<urlBase>` respectively. If any of these values are not set then the previous default behaviour of deriving it from `.connect.urlBase` with a hard-coded subdomain is used instead so this isn't a breaking change.
- Add `.connect.apiServername` if the hostname and SNI for the JWT authenticated (with webPKI) API need to differ.
- Add `.connect.apiExtraEndpoints` supporting exposing the JWT authenticated (with webPKI) API under additional servernames+hostnames - useful when they are multiple network paths to the API.
- Add `.connect.mtlsExtraServerNames` supporting exposing the SPIFFE mTLS authenticated API under additional servernames - useful when they are multiple network paths to the API.
- Add `.connect.xdsExtraServerNames` supporting exposing the xDS server under additional servernames - useful when they are multiple network paths to the xDS server.

`.connect.urlBase` is now considered deprecated and may be removed in a future chart version.

Chart deployers are encouraged to setup DNS resolution for `.connect.apiAddress`, `.connect.mtlsServerName` and `.connect.xdsServerName` - thereby allowing API consumers to dial a consistent target without having to set a separate SNI in the TLS handshake.

This removes the forcing of the SNI hostname to have particular subdomains, giving chart deployers full control of how they want to expose Connect.