### PR TITLE
Bump cofide-connect and cofide-credex app versions to latest releases

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.19.1
+version: 0.20.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.53.0"
+appVersion: "v0.54.0"
 
 maintainers:
   - name: Cofide

--- a/charts/cofide-credex/Chart.yaml
+++ b/charts/cofide-credex/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cofide-credex
 description: Helm chart to deploy Cofide Credex
 type: application
-version: 0.3.2
-appVersion: "v0.13.0"
+version: 0.4.0
+appVersion: "v0.16.0"
 maintainers:
   - name: Cofide
     url: https://cofide.io


### PR DESCRIPTION
As title says.

Making sure someone installing the charts gets the latest (for now) application versions by default.