### PR TITLE
Support setting S3 encryption method

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.21.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.54.0"
+appVersion: "v0.57.0"
 
 maintainers:
   - name: Cofide

--- a/charts/cofide-connect/templates/configmap.yaml
+++ b/charts/cofide-connect/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{- $datastoreUsed := 0 -}}
+{{- $trustBundleStoreBackendUsed := 0 -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,6 +13,9 @@ data:
     spiffe_endpoint_socket: {{ .Values.connect.spiffeEndpointSocket }}
     trust_bundle_store_backend:
       {{- with .Values.connect.trustBundleStoreBackend.s3 }}
+      {{- if .enabled }}
+        {{- $trustBundleStoreBackendUsed = add $trustBundleStoreBackendUsed 1 }}
+      {{- end }}
       s3:
         enabled: {{ .enabled }}
         bucket: {{ .bucket }}
@@ -33,6 +37,9 @@ data:
         {{- end }}
       {{- end }}
       {{- with .Values.connect.trustBundleStoreBackend.gcs }}
+      {{- if .enabled }}
+        {{- $trustBundleStoreBackendUsed = add $trustBundleStoreBackendUsed 1 }}
+      {{- end }}
       gcs:
         enabled: {{ .enabled }}
         bucket: {{ .bucket }}
@@ -128,4 +135,7 @@ data:
             {{- end }}
 {{- if ne $datastoreUsed 1 }}
 {{- fail (printf "You must enable exactly one datastore. There are %d enabled." $datastoreUsed) }}
+{{- end }}
+{{- if ne $trustBundleStoreBackendUsed 1 }}
+{{- fail (printf "You must enable exactly one trust bundle store backend. There are %d enabled." $trustBundleStoreBackendUsed) }}
 {{- end }}

--- a/charts/cofide-connect/templates/configmap.yaml
+++ b/charts/cofide-connect/templates/configmap.yaml
@@ -16,6 +16,14 @@ data:
         enabled: {{ .enabled }}
         bucket: {{ .bucket }}
         use_path_style: {{ .usePathStyle }}
+        {{- with .encryption }}
+        {{- if and .kmsKeyId (ne .type "SSE-KMS") }}
+        {{- fail (printf "connect.trustBundleStoreBackend.s3.encryption.kmsKeyId is only valid when type is \"SSE-KMS\" (got type: %q, kmsKeyId: %q)" .type .kmsKeyId) }}
+        {{- end }}
+        encryption:
+          type: {{ .type | quote }}
+          kms_key_id: {{ .kmsKeyId | quote }}
+        {{- end }}
         {{- with .oidc }}
         oidc:
           enabled: {{ .enabled }}

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -74,6 +74,23 @@
                       "type": "boolean",
                       "description": "Determines if path-style addressing is used to access S3 buckets (if false, virtual-hosted-style is used)."
                     },
+                    "encryption": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "Configuration for server-side encryption of objects written to the S3 trust bundle store.",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": ["", "SSE-S3", "SSE-KMS"],
+                          "description": "Server-side encryption mode for objects written to S3: \"\" (bucket default), \"SSE-S3\", or \"SSE-KMS\"."
+                        },
+                        "kmsKeyId": {
+                          "type": "string",
+                          "description": "KMS key to use when type is \"SSE-KMS\", as a key ID, key ARN, alias name, or alias ARN. Empty uses the account's default KMS key."
+                        }
+                      },
+                      "required": ["type", "kmsKeyId"]
+                    },
                     "oidc": {
                       "type": "object",
                       "additionalProperties": false,
@@ -104,7 +121,7 @@
                       ]
                     }
                   },
-                  "required": ["enabled", "bucket", "usePathStyle", "oidc"]
+                  "required": ["enabled", "bucket", "usePathStyle", "encryption", "oidc"]
                 }
               }
             },

--- a/charts/cofide-connect/values.schema.json
+++ b/charts/cofide-connect/values.schema.json
@@ -54,122 +54,115 @@
         "trustBundleStoreBackend": {
           "type": "object",
           "description": "Configuration of the trust bundle store backend to use. Only one backend may be enabled.",
-          "anyOf": [
-            {
+          "properties": {
+            "s3": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Configuration for S3 trust bundle store backend.",
               "properties": {
-                "s3": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "True to enable the S3 backend."
+                },
+                "bucket": {
+                  "type": "string",
+                  "description": "Name of bucket to use as trust bundle store."
+                },
+                "usePathStyle": {
+                  "type": "boolean",
+                  "description": "Determines if path-style addressing is used to access S3 buckets (if false, virtual-hosted-style is used)."
+                },
+                "encryption": {
                   "type": "object",
                   "additionalProperties": false,
-                  "description": "Configuration for S3 trust bundle store backend.",
+                  "description": "Configuration for server-side encryption of objects written to the S3 trust bundle store.",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": ["", "SSE-S3", "SSE-KMS"],
+                      "description": "Server-side encryption mode for objects written to S3: \"\" (bucket default), \"SSE-S3\", or \"SSE-KMS\"."
+                    },
+                    "kmsKeyId": {
+                      "type": "string",
+                      "description": "KMS key to use when type is \"SSE-KMS\", as a key ID, key ARN, alias name, or alias ARN. Empty uses the account's default KMS key."
+                    }
+                  },
+                  "required": ["type", "kmsKeyId"]
+                },
+                "oidc": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Configuration to use OIDC to access S3, exchanging the Connect server's SVID for AWS credentials.",
                   "properties": {
                     "enabled": {
                       "type": "boolean",
-                      "description": "True to enable the S3 backend."
+                      "description": "True to use OIDC with the server's SVID to get temporary credentials to access S3 using OIDC, otherwise the AWS credentials will be sourced from the environment."
                     },
-                    "bucket": {
+                    "awsRegion": {
                       "type": "string",
-                      "description": "Name of bucket to use as trust bundle store."
+                      "description": "Region to set in the AWS config when obtaining credentials through OIDC."
                     },
-                    "usePathStyle": {
-                      "type": "boolean",
-                      "description": "Determines if path-style addressing is used to access S3 buckets (if false, virtual-hosted-style is used)."
+                    "iamRoleARN": {
+                      "type": "string",
+                      "description": "ARN of AWS role to assume when obtaining credentials through OIDC."
                     },
-                    "encryption": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "description": "Configuration for server-side encryption of objects written to the S3 trust bundle store.",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "enum": ["", "SSE-S3", "SSE-KMS"],
-                          "description": "Server-side encryption mode for objects written to S3: \"\" (bucket default), \"SSE-S3\", or \"SSE-KMS\"."
-                        },
-                        "kmsKeyId": {
-                          "type": "string",
-                          "description": "KMS key to use when type is \"SSE-KMS\", as a key ID, key ARN, alias name, or alias ARN. Empty uses the account's default KMS key."
-                        }
-                      },
-                      "required": ["type", "kmsKeyId"]
-                    },
-                    "oidc": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "description": "Configuration to use OIDC to access S3, exchanging the Connect server's SVID for AWS credentials.",
-                      "properties": {
-                        "enabled": {
-                          "type": "boolean",
-                          "description": "True to use OIDC with the server's SVID to get temporary credentials to access S3 using OIDC, otherwise the AWS credentials will be sourced from the environment."
-                        },
-                        "awsRegion": {
-                          "type": "string",
-                          "description": "Region to set in the AWS config when obtaining credentials through OIDC."
-                        },
-                        "iamRoleARN": {
-                          "type": "string",
-                          "description": "ARN of AWS role to assume when obtaining credentials through OIDC."
-                        },
-                        "audience": {
-                          "type": "string",
-                          "description": "Audience expected by the OIDC provider in AWS."
-                        }
-                      },
-                      "required": [
-                        "enabled",
-                        "awsRegion",
-                        "iamRoleARN",
-                        "audience"
-                      ]
+                    "audience": {
+                      "type": "string",
+                      "description": "Audience expected by the OIDC provider in AWS."
                     }
                   },
-                  "required": ["enabled", "bucket", "usePathStyle", "encryption", "oidc"]
+                  "required": [
+                    "enabled",
+                    "awsRegion",
+                    "iamRoleARN",
+                    "audience"
+                  ]
                 }
-              }
+              },
+              "required": ["enabled", "bucket", "usePathStyle", "encryption", "oidc"]
             },
-            {
+            "gcs": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Configuration for GCS trust bundle store backend.",
               "properties": {
-                "gcs": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "True to enable the GCS backend."
+                },
+                "bucket": {
+                  "type": "string",
+                  "description": "Name of bucket to use as trust bundle store."
+                },
+                "oidc": {
                   "type": "object",
                   "additionalProperties": false,
-                  "description": "Configuration for GCS trust bundle store backend.",
+                  "description": "Configuration to use OIDC to access GCS, exchanging the Connect server's SVID for GCP credentials.",
                   "properties": {
                     "enabled": {
                       "type": "boolean",
-                      "description": "True to enable the GCS backend."
+                      "description": "True to use OIDC with the server's SVID to get temporary credentials to access GCS using OIDC, otherwise the GCP credentials will be sourced from the environment."
                     },
-                    "bucket": {
+                    "workloadIdentityProvider": {
                       "type": "string",
-                      "description": "Name of bucket to use as trust bundle store."
+                      "description": "Fully qualified identifier of GCP workload identity provider to use when obtaining credentials through OIDC. Must be in the form projects/PROJECT_ID/locations/global/workloadIdentityPools/WORKLOAD_IDENTITY_POOL_NAME/providers/WORKLOAD_IDENTITY_PROVIDER_NAME."
                     },
-                    "oidc": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "description": "Configuration to use OIDC to access GCS, exchanging the Connect server's SVID for GCP credentials.",
-                      "properties": {
-                        "enabled": {
-                          "type": "boolean",
-                          "description": "True to use OIDC with the server's SVID to get temporary credentials to access GCS using OIDC, otherwise the GCP credentials will be sourced from the environment."
-                        },
-                        "workloadIdentityProvider": {
-                          "type": "string",
-                          "description": "Fully qualified identifier of GCP workload identity provider to use when obtaining credentials through OIDC. Must be in the form projects/PROJECT_ID/locations/global/workloadIdentityPools/WORKLOAD_IDENTITY_POOL_NAME/providers/WORKLOAD_IDENTITY_PROVIDER_NAME."
-                        },
-                        "audience": {
-                          "type": "string",
-                          "description": "Audience expected by the OIDC provider in GCP."
-                        }
-                      },
-                      "required": [
-                        "enabled",
-                        "workloadIdentityProvider",
-                        "audience"
-                      ]
+                    "audience": {
+                      "type": "string",
+                      "description": "Audience expected by the OIDC provider in GCP."
                     }
                   },
-                  "required": ["enabled", "bucket", "oidc"]
+                  "required": [
+                    "enabled",
+                    "workloadIdentityProvider",
+                    "audience"
+                  ]
                 }
-              }
+              },
+              "required": ["enabled", "bucket", "oidc"]
             }
-          ]
+          },
+          "required": ["s3", "gcs"]
         },
         "datastore": {
           "type": "object",

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -41,6 +41,12 @@ connect:
       bucket: ""
       # Determines if path-style addressing is used to access S3 buckets (if false, virtual-hosted-style is used).
       usePathStyle: false
+      # Configuration for server-side encryption of objects written to the S3 trust bundle store.
+      encryption:
+        # Server-side encryption mode for objects written to S3: "" (bucket default), "SSE-S3", or "SSE-KMS".
+        type: ""
+        # KMS key to use when type is "SSE-KMS", as a key ID, key ARN, alias name, or alias ARN. Empty uses the account's default KMS key.
+        kmsKeyId: ""
       # Configuration to use OIDC to access S3, exchanging the Connect server's SVID for AWS credentials.
       oidc:
         # True to use OIDC with the server's SVID to get temporary credentials to access S3 using OIDC, otherwise the AWS credentials will be sourced from the environment.


### PR DESCRIPTION
- [Support setting S3 encryption method](https://github.com/cofide/helm-charts/commit/90de98c8416a82a8082707a8620c45d93fbbd8fd) - helm chart support for new config added in https://github.com/cofide/cofide-connect/pull/2072
- [Correct bad attempt at validating that one of the trust bundle store backends was valid](https://github.com/cofide/helm-charts/commit/ed6c793ea3753c15d807ad9b86269b307d1ea6fb) - resolves an issue with the JSON schema validation that meant only one of the S3 or GCS configs had to be valid in the schema. Now this is always applied. This should have no impact on consumers of the chart as the defaults are valid in the schema already. The only extra validation is to enforce that exactly one of the trustBundleStoreBackends is enabled - which was previously only checked once the application was already running.
