### PR TITLE
Add policyDebug toggle to Credex chart

### DIFF
--- a/charts/cofide-credex/Chart.yaml
+++ b/charts/cofide-credex/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cofide-credex
 description: Helm chart to deploy Cofide Credex
 type: application
-version: 0.6.0
-appVersion: "v0.17.0"
+version: 0.7.0
+appVersion: "v0.17.1"
 maintainers:
   - name: Cofide
     url: https://cofide.io

--- a/charts/cofide-credex/templates/configmap.yaml
+++ b/charts/cofide-credex/templates/configmap.yaml
@@ -28,7 +28,8 @@ data:
   OAUTH_PRIVATE_KEY_FILE: {{ .Values.credex.signing.privateKeyFile | quote }}
   {{- end }}
   SPIFFE_ENDPOINT_SOCKET: {{ .Values.credex.spiffeEndpointSocket | quote }}
-  SERVER_DEBUG: {{ .Values.credex.debug | toString | quote }}
+  SERVER_DEBUG: {{ .Values.credex.serverDebug | toString | quote }}
+  POLICY_DEBUG: {{ .Values.credex.policyDebug | toString | quote }}
   PORT: {{ include "cofide-credex.targetPort" . | quote }}
   {{- if .Values.credex.tls.enabled }}
   TLS_CERT_FILE: {{ .Values.credex.tls.certFile | quote }}

--- a/charts/cofide-credex/values.schema.json
+++ b/charts/cofide-credex/values.schema.json
@@ -146,9 +146,13 @@
           "type": "string",
           "description": "SPIFFE workload API endpoint socket."
         },
-        "debug": {
+        "serverDebug": {
           "type": "boolean",
-          "description": "Enable debug logging."
+          "description": "Enable server debug logging."
+        },
+        "policyDebug": {
+          "type": "boolean",
+          "description": "Enable policy debug logging."
         },
         "telemetry": {
           "type": "object",
@@ -274,7 +278,8 @@
         "tls",
         "signing",
         "spiffeEndpointSocket",
-        "debug",
+        "serverDebug",
+        "policyDebug",
         "trustedIssuers",
         "extraEnv"
       ],

--- a/charts/cofide-credex/values.yaml
+++ b/charts/cofide-credex/values.yaml
@@ -61,8 +61,10 @@ credex:
     privateKeySecret: oauth-private-key
   # SPIFFE workload API endpoint socket.
   spiffeEndpointSocket: unix:///run/spire/sockets/spire-agent.sock
-  # Enable debug logging.
-  debug: false
+  # Enable server debug logging.
+  serverDebug: false
+  # Enable policy debug logging.
+  policyDebug: false
   # Telemetry config (OpenTelemetry-based).
   telemetry:
     # Whether to enable pushing of metrics and traces telemetry data (via OpenTelemetry SDK).

--- a/charts/cofide-credex/values.yaml
+++ b/charts/cofide-credex/values.yaml
@@ -63,7 +63,7 @@ credex:
   spiffeEndpointSocket: unix:///run/spire/sockets/spire-agent.sock
   # Enable server debug logging.
   serverDebug: false
-  # Enable policy debug logging.
+  # Enable policy matching debug logging.
   policyDebug: false
   # Telemetry config (OpenTelemetry-based).
   telemetry:


### PR DESCRIPTION
Breaking: renames `credex.debug` chart value to `credex.serverDebug` to accommodate new `policyDebug` config option.