### PR TITLE
Enable audit by default

### DIFF
--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.0
+version: 0.22.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -159,7 +159,7 @@ connect:
       connectDatastore:
         # EnabledEvents is the list of event types to enable. Use "all" to enable every event type.
         # Examples: trust_zone_creation, workload_deletion, cluster_creation, node_attestation.
-        enabledEvents: []
+        enabledEvents: ["all"]
         # DisabledEvents is subtracted from the resolved enabledEvents list.
         # Examples: trust_zone_deletion, cluster_deletion.
         disabledEvents: []


### PR DESCRIPTION
If a chart deployer wanted audit disabled and found it enabled unexpectedly that is better than someone expecting audit to be enabled and finding it hasn't been.

This flips the default for audit events being stored within Connect's datastore from off to on to align with the above.