### PR TITLE
Enable Connect as credex's default audit backend

### DIFF
--- a/charts/cofide-credex/Chart.yaml
+++ b/charts/cofide-credex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cofide-credex
 description: Helm chart to deploy Cofide Credex
 type: application
-version: 0.7.0
+version: 0.8.0
 appVersion: "v0.17.1"
 maintainers:
   - name: Cofide

--- a/charts/cofide-credex/values.yaml
+++ b/charts/cofide-credex/values.yaml
@@ -74,7 +74,7 @@ credex:
   # Audit configuration.
   audit:
     # Audit backend type. Supported values: "log" (logging to stdout), "connect" (sending to Cofide Connect service; requires setting credex.connectURL).
-    backend: log
+    backend: connect
   # Trusted issuers for token exchange. Each entry generates a numbered set of
   # TRUSTED_ISSUER_n / TRUSTED_ISSUER_JWKS_URL_n / TRUSTED_ISSUER_ALLOWED_AUDIENCES_n env vars.
   trustedIssuers: []


### PR DESCRIPTION
Pairs with https://github.com/cofide/helm-charts/pull/138.

This means the default behaviour is to send audit events to the Connect control plane, which is a less surprising default than audit events not being visible in the control plane.