### PR TITLE
Support explicit Connect config in cofide-observer chart

### DIFF
--- a/charts/cofide-observer/Chart.yaml
+++ b/charts/cofide-observer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cofide-observer
 description: Helm chart to deploy Cofide Observer
 type: application
-version: 0.3.6
+version: 0.4.0
 appVersion: "v0.7.0"
 maintainers:
   - name: Cofide

--- a/charts/cofide-observer/ci/mtls-values.yaml
+++ b/charts/cofide-observer/ci/mtls-values.yaml
@@ -1,0 +1,5 @@
+observer:
+  # Test new mTLS gRPC target / SPIFFE ID connect fields.
+  connectMTLSGRPCTarget: connect.example.org:8443
+  connectMTLSServerName: connect.example.org
+  connectSPIFFEID: spiffe://example.org/connect

--- a/charts/cofide-observer/ci/required-values.yaml
+++ b/charts/cofide-observer/ci/required-values.yaml
@@ -1,5 +1,4 @@
 observer:
-  # URL of Cofide Connect API. Required.
+  # Test legacy (deprecated) connect fields.
   connectURL: api.connect.example.org:4321
-  # SPIFFE trust domain of Cofide Connect API. Required.
   connectTrustDomain: connect.example.org

--- a/charts/cofide-observer/templates/NOTES.txt
+++ b/charts/cofide-observer/templates/NOTES.txt
@@ -1,0 +1,8 @@
+{{- if .Values.observer.connectURL }}
+
+WARNING: observer.connectURL is deprecated, use observer.connectMTLSGRPCTarget instead.
+{{- end }}
+{{- if .Values.observer.connectTrustDomain }}
+
+WARNING: observer.connectTrustDomain is deprecated, use observer.connectSPIFFEID instead.
+{{- end }}

--- a/charts/cofide-observer/templates/configmap.yaml
+++ b/charts/cofide-observer/templates/configmap.yaml
@@ -3,7 +3,16 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}
 data:
-  CONNECT_URL: {{ required "Connect URL is required" .Values.observer.connectURL }}
-  CONNECT_TRUST_DOMAIN: {{ required "Connect Trust Domain is required" .Values.observer.connectTrustDomain }}
+  {{- if and (not .Values.observer.connectMTLSGRPCTarget) (not .Values.observer.connectURL) }}
+    {{- fail "One of observer.connectMTLSGRPCTarget or observer.connectURL must be set" }}
+  {{- end }}
+  {{- if and (not .Values.observer.connectSPIFFEID) (not .Values.observer.connectTrustDomain) }}
+    {{- fail "One of observer.connectSPIFFEID or observer.connectTrustDomain must be set" }}
+  {{- end }}
+  CONNECT_MTLS_GRPC_TARGET: {{ .Values.observer.connectMTLSGRPCTarget | quote }}
+  CONNECT_MTLS_SERVER_NAME: {{ .Values.observer.connectMTLSServerName | quote }}
+  CONNECT_URL: {{ .Values.observer.connectURL | quote }}
+  CONNECT_SPIFFE_ID: {{ .Values.observer.connectSPIFFEID | quote }}
+  CONNECT_TRUST_DOMAIN: {{ .Values.observer.connectTrustDomain | quote }}
   RESYNC_ENABLED: {{ .Values.observer.resyncEnabled | quote }}
   RESYNC_PERIOD: {{ .Values.observer.resyncPeriod | quote }}

--- a/charts/cofide-observer/values.schema.json
+++ b/charts/cofide-observer/values.schema.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Cofide Observer values",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "observer": {
+      "type": "object",
+      "description": "Configuration settings for the Observer service.",
+      "additionalProperties": false,
+      "properties": {
+        "connectURL": {
+          "type": "string",
+          "description": "DEPRECATED: use connectMTLSGRPCTarget instead. URL of the Cofide Connect API."
+        },
+        "connectMTLSGRPCTarget": {
+          "type": "string",
+          "description": "gRPC target for the Connect API. One of connectMTLSGRPCTarget or connectURL is required."
+        },
+        "connectMTLSServerName": {
+          "type": "string",
+          "description": "Optional SNI override to use when calling the Connect API."
+        },
+        "connectTrustDomain": {
+          "type": "string",
+          "description": "DEPRECATED: use connectSPIFFEID instead. SPIFFE trust domain of the Cofide Connect API."
+        },
+        "connectSPIFFEID": {
+          "type": "string",
+          "description": "SPIFFE ID of the Cofide Connect API. One of connectSPIFFEID or connectTrustDomain is required."
+        },
+        "resyncEnabled": {
+          "type": "boolean",
+          "description": "Controls whether periodic resync is active."
+        },
+        "resyncPeriod": {
+          "type": "string",
+          "description": "Resync interval as a Go duration string."
+        }
+      },
+      "required": [
+        "connectURL",
+        "connectMTLSGRPCTarget",
+        "connectMTLSServerName",
+        "connectTrustDomain",
+        "connectSPIFFEID",
+        "resyncEnabled",
+        "resyncPeriod"
+      ]
+    },
+    "replicaCount": {
+      "type": "integer",
+      "description": "Number of replicas for the Observer deployment.",
+      "minimum": 0
+    },
+    "image": {
+      "type": "object",
+      "description": "Container image configuration.",
+      "additionalProperties": false,
+      "properties": {
+        "registry": {
+          "type": "string",
+          "description": "Container image registry."
+        },
+        "repository": {
+          "type": "string",
+          "description": "Container image repository."
+        },
+        "pullPolicy": {
+          "type": "string",
+          "description": "Image pull policy.",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "tag": {
+          "type": "string",
+          "description": "Image tag. Defaults to the chart's appVersion when empty."
+        }
+      },
+      "required": ["registry", "repository", "pullPolicy"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "List of image pull secrets.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Override for the chart name."
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override for the fully-qualified app name."
+    },
+    "serviceAccount": {
+      "type": "object",
+      "description": "Service account configuration.",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Whether to create a service account."
+        },
+        "automount": {
+          "type": "boolean",
+          "description": "Whether to automount the service account token."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service account.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the service account to use. If empty and create is true, a name is generated using the fullname template."
+        }
+      },
+      "required": ["create", "automount"]
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Annotations to add to the pod.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Labels to add to the pod.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Security context for the pod."
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Security context for the container."
+    },
+    "resources": {
+      "type": "object",
+      "description": "CPU/memory resource requests and limits for the container."
+    },
+    "livenessProbe": {
+      "description": "Liveness probe configuration for the container."
+    },
+    "readinessProbe": {
+      "description": "Readiness probe configuration for the container."
+    },
+    "volumes": {
+      "type": "array",
+      "description": "Additional volumes to mount into the pod.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "volumeMounts": {
+      "type": "array",
+      "description": "Additional volume mounts for the container.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector for pod scheduling.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Tolerations for pod scheduling.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity rules for pod scheduling."
+    }
+  },
+  "required": ["observer", "replicaCount", "image"]
+}

--- a/charts/cofide-observer/values.yaml
+++ b/charts/cofide-observer/values.yaml
@@ -3,10 +3,16 @@
 # Declare variables to be passed into your templates.
 
 observer:
-  # URL of Cofide Connect API. Required.
-  connectURL:
-  # SPIFFE trust domain of Cofide Connect API. Required.
-  connectTrustDomain:
+  # DEPRECATED: use connectMTLSGRPCTarget instead. URL of Cofide Connect API.
+  connectURL: ""
+  # gRPC target (host:port) for Cofide Connect's mTLS endpoint. One of connectMTLSGRPCTarget or connectURL is required.
+  connectMTLSGRPCTarget: ""
+  # Optional TLS server name override to use when verifying Cofide Connect's mTLS endpoint.
+  connectMTLSServerName: ""
+  # DEPRECATED: use connectSPIFFEID instead. SPIFFE trust domain of Cofide Connect API.
+  connectTrustDomain: ""
+  # SPIFFE ID of Cofide Connect API. One of connectSPIFFEID or connectTrustDomain is required.
+  connectSPIFFEID: ""
   # Controls whether periodic resync is active (default: false).
   resyncEnabled: false
   # Sets the resync interval as a Go duration string (default: 10m).

--- a/charts/cofide-observer/values.yaml
+++ b/charts/cofide-observer/values.yaml
@@ -5,7 +5,7 @@
 observer:
   # DEPRECATED: use connectMTLSGRPCTarget instead. URL of Cofide Connect API.
   connectURL: ""
-  # gRPC target (host:port) for Cofide Connect's mTLS endpoint. One of connectMTLSGRPCTarget or connectURL is required.
+  # gRPC target (https://grpc.io/docs/guides/custom-name-resolution) for Cofide Connect's mTLS endpoint. One of connectMTLSGRPCTarget or connectURL is required.
   connectMTLSGRPCTarget: ""
   # Optional TLS server name override to use when verifying Cofide Connect's mTLS endpoint.
   connectMTLSServerName: ""


### PR DESCRIPTION
Helm chart now supports explicit values for:
- connect MTLS gRPC target
- connect MTLS server name (optional)
- connect SPIFFE ID

Deprecating:
- connect URL
- connect trust domain

Using the new values (with cofide-observer v0.7.0 or later) means the application makes no assumptions about the subdomain of the Connect API, the SNI that must be set when calling it or the path of its SPIFFE ID.