### PR TITLE
Support explicit Connect config in cofide-agent chart

### DIFF
--- a/charts/cofide-agent/Chart.yaml
+++ b/charts/cofide-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-agent/ci/additional-env-values.yaml
+++ b/charts/cofide-agent/ci/additional-env-values.yaml
@@ -1,0 +1,8 @@
+agent:
+  env:
+    # Test that additional (non-schema-defined) string env vars are permitted.
+    COFIDE_CONNECT_TLS_GRPC_TARGET: connect.example.org:8443
+    COFIDE_CONNECT_MTLS_GRPC_TARGET: connect.example.org:8444
+    COFIDE_CONNECT_XDS_GRPC_TARGET: connect.example.org:8445
+    COFIDE_CONNECT_SPIFFE_ID: spiffe://example.org/connect
+    CUSTOM_ENV_VAR: some-value

--- a/charts/cofide-agent/ci/connect-values.yaml
+++ b/charts/cofide-agent/ci/connect-values.yaml
@@ -1,0 +1,10 @@
+agent:
+  env:
+    # Test new TLS/mTLS/xDS connect fields.
+    COFIDE_CONNECT_TLS_GRPC_TARGET: connect.example.org:8443
+    COFIDE_CONNECT_TLS_SERVER_NAME: connect.example.org
+    COFIDE_CONNECT_MTLS_GRPC_TARGET: connect.example.org:8444
+    COFIDE_CONNECT_MTLS_SERVER_NAME: connect.example.org
+    COFIDE_CONNECT_XDS_GRPC_TARGET: connect.example.org:8445
+    COFIDE_CONNECT_XDS_SERVER_NAME: connect.example.org
+    COFIDE_CONNECT_SPIFFE_ID: spiffe://example.org/connect

--- a/charts/cofide-agent/ci/legacy-values.yaml
+++ b/charts/cofide-agent/ci/legacy-values.yaml
@@ -1,0 +1,5 @@
+agent:
+  env:
+    # Test legacy (deprecated) connect fields.
+    COFIDE_CONNECT_URL: api.connect.example.org:4321
+    COFIDE_CONNECT_TRUST_DOMAIN: connect.example.org

--- a/charts/cofide-agent/templates/NOTES.txt
+++ b/charts/cofide-agent/templates/NOTES.txt
@@ -1,0 +1,8 @@
+{{- if .Values.agent.env.COFIDE_CONNECT_URL }}
+
+WARNING: agent.env.COFIDE_CONNECT_URL is deprecated, use agent.env.COFIDE_CONNECT_TLS_GRPC_TARGET, agent.env.COFIDE_CONNECT_MTLS_GRPC_TARGET and agent.env.COFIDE_CONNECT_XDS_GRPC_TARGET instead.
+{{- end }}
+{{- if .Values.agent.env.COFIDE_CONNECT_TRUST_DOMAIN }}
+
+WARNING: agent.env.COFIDE_CONNECT_TRUST_DOMAIN is deprecated, use agent.env.COFIDE_CONNECT_SPIFFE_ID instead.
+{{- end }}

--- a/charts/cofide-agent/templates/configmap.yaml
+++ b/charts/cofide-agent/templates/configmap.yaml
@@ -3,6 +3,12 @@ kind: ConfigMap
 metadata:
   name: cofide-agent
 data:
+  {{- if and (not .Values.agent.env.COFIDE_CONNECT_URL) (or (not .Values.agent.env.COFIDE_CONNECT_TLS_GRPC_TARGET) (not .Values.agent.env.COFIDE_CONNECT_MTLS_GRPC_TARGET) (not .Values.agent.env.COFIDE_CONNECT_XDS_GRPC_TARGET)) }}
+    {{- fail "Either agent.env.COFIDE_CONNECT_URL or all of agent.env.COFIDE_CONNECT_TLS_GRPC_TARGET, agent.env.COFIDE_CONNECT_MTLS_GRPC_TARGET and agent.env.COFIDE_CONNECT_XDS_GRPC_TARGET must be set" }}
+  {{- end }}
+  {{- if and (not .Values.agent.env.COFIDE_CONNECT_SPIFFE_ID) (not .Values.agent.env.COFIDE_CONNECT_TRUST_DOMAIN) }}
+    {{- fail "One of agent.env.COFIDE_CONNECT_SPIFFE_ID or agent.env.COFIDE_CONNECT_TRUST_DOMAIN must be set" }}
+  {{- end }}
 {{- range $key, $value := .Values.agent.env }}
   {{ $key }}: {{ $value | quote }}
 {{- end }}

--- a/charts/cofide-agent/values.schema.json
+++ b/charts/cofide-agent/values.schema.json
@@ -1,0 +1,290 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Cofide Agent values",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "agent": {
+      "type": "object",
+      "description": "Configuration settings for the Cofide Agent.",
+      "additionalProperties": false,
+      "properties": {
+        "env": {
+          "type": "object",
+          "description": "Environment variables passed to the Cofide Agent container.",
+          "additionalProperties": false,
+          "properties": {
+            "AGENT_PROFILE": {
+              "type": "string",
+              "description": "Agent profile to run under, e.g. 'kubernetes'."
+            },
+            "AGENT_TOKEN": {
+              "type": "string",
+              "description": "Token used by the agent to authenticate with Cofide Connect."
+            },
+            "CLUSTER_ID": {
+              "type": "string",
+              "description": "Identifier of the Kubernetes cluster the agent is running in."
+            },
+            "COFIDE_CONNECT_MTLS_GRPC_TARGET": {
+              "type": "string",
+              "description": "gRPC target for Cofide Connect's mTLS endpoint, used for API calls after registration."
+            },
+            "COFIDE_CONNECT_MTLS_SERVER_NAME": {
+              "type": "string",
+              "description": "Optional SNI override to use when calling Cofide Connect's mTLS endpoint."
+            },
+            "COFIDE_CONNECT_SPIFFE_ID": {
+              "type": "string",
+              "description": "SPIFFE ID of Cofide Connect, used for both the mTLS and xDS connections."
+            },
+            "COFIDE_CONNECT_TLS_GRPC_TARGET": {
+              "type": "string",
+              "description": "gRPC target for Cofide Connect's plain TLS endpoint, used when this agent registers the trust zone."
+            },
+            "COFIDE_CONNECT_TLS_SERVER_NAME": {
+              "type": "string",
+              "description": "Optional SNI override to use when calling Cofide Connect's plain TLS endpoint."
+            },
+            "COFIDE_CONNECT_TRUST_DOMAIN": {
+              "type": "string",
+              "description": "DEPRECATED: use COFIDE_CONNECT_SPIFFE_ID instead. SPIFFE trust domain of Cofide Connect."
+            },
+            "COFIDE_CONNECT_URL": {
+              "type": "string",
+              "description": "DEPRECATED: use COFIDE_CONNECT_MTLS_GRPC_TARGET instead. URL of Cofide Connect."
+            },
+            "COFIDE_CONNECT_XDS_GRPC_TARGET": {
+              "type": "string",
+              "description": "gRPC target for Cofide Connect's xDS server, used to fetch federated services config."
+            },
+            "COFIDE_CONNECT_XDS_SERVER_NAME": {
+              "type": "string",
+              "description": "Optional SNI override to use when calling Cofide Connect's xDS server."
+            },
+            "MANAGEMENT_ZONE": {
+              "type": "boolean",
+              "description": "Whether this agent is running in the management zone."
+            },
+            "OIDC_ENDPOINT_ENABLED": {
+              "type": "boolean",
+              "description": "Whether the agent's OIDC discovery endpoint is enabled."
+            },
+            "TRUST_DOMAIN": {
+              "type": "string",
+              "description": "SPIFFE trust domain this agent belongs to."
+            },
+            "TRUST_ZONE_ID": {
+              "type": "string",
+              "description": "Identifier of the trust zone this agent belongs to."
+            }
+          },
+          "required": [
+            "AGENT_PROFILE",
+            "AGENT_TOKEN",
+            "CLUSTER_ID",
+            "COFIDE_CONNECT_MTLS_GRPC_TARGET",
+            "COFIDE_CONNECT_MTLS_SERVER_NAME",
+            "COFIDE_CONNECT_SPIFFE_ID",
+            "COFIDE_CONNECT_TLS_GRPC_TARGET",
+            "COFIDE_CONNECT_TLS_SERVER_NAME",
+            "COFIDE_CONNECT_TRUST_DOMAIN",
+            "COFIDE_CONNECT_URL",
+            "COFIDE_CONNECT_XDS_GRPC_TARGET",
+            "COFIDE_CONNECT_XDS_SERVER_NAME",
+            "MANAGEMENT_ZONE",
+            "OIDC_ENDPOINT_ENABLED",
+            "TRUST_DOMAIN",
+            "TRUST_ZONE_ID"
+          ]
+        }
+      },
+      "required": ["env"]
+    },
+    "xdsServer": {
+      "type": "object",
+      "description": "Configuration for the Agent's xDS server.",
+      "additionalProperties": false,
+      "properties": {
+        "service": {
+          "type": "object",
+          "description": "Kubernetes Service exposing the Agent's xDS server.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether to create a Service for the xDS server."
+            },
+            "type": {
+              "type": "string",
+              "description": "Kubernetes Service type."
+            },
+            "port": {
+              "type": "integer",
+              "description": "Port the xDS Service listens on."
+            },
+            "targetPort": {
+              "type": "integer",
+              "description": "Target port on the pod. Defaults to port when unset."
+            },
+            "protocol": {
+              "type": "string",
+              "description": "Service port protocol. Defaults to TCP."
+            },
+            "portName": {
+              "type": "string",
+              "description": "Name of the Service port. Defaults to 'grpc-xds'."
+            },
+            "labels": {
+              "type": "object",
+              "description": "Additional labels for the Service.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Additional annotations for the Service.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["enabled", "type", "port"]
+        }
+      },
+      "required": ["service"]
+    },
+    "replicaCount": {
+      "type": "integer",
+      "description": "Number of replicas for the Agent deployment.",
+      "minimum": 0
+    },
+    "image": {
+      "type": "object",
+      "description": "Container image configuration.",
+      "additionalProperties": false,
+      "properties": {
+        "registry": {
+          "type": "string",
+          "description": "Container image registry."
+        },
+        "repository": {
+          "type": "string",
+          "description": "Container image repository."
+        },
+        "pullPolicy": {
+          "type": "string",
+          "description": "Image pull policy.",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "tag": {
+          "type": "string",
+          "description": "Image tag. Defaults to the chart's appVersion when empty."
+        }
+      },
+      "required": ["registry", "repository", "pullPolicy"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "List of image pull secrets.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Override for the chart name."
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override for the fully-qualified app name."
+    },
+    "serviceAccount": {
+      "type": "object",
+      "description": "Service account configuration.",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Whether to create a service account."
+        },
+        "automount": {
+          "type": "boolean",
+          "description": "Whether to automount the service account token."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service account.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the service account to use. If empty and create is true, a name is generated using the fullname template."
+        }
+      },
+      "required": ["create", "automount"]
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Annotations to add to the pod.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Labels to add to the pod.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Security context for the pod."
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Security context for the container."
+    },
+    "resources": {
+      "type": "object",
+      "description": "CPU/memory resource requests and limits for the container."
+    },
+    "volumes": {
+      "type": "array",
+      "description": "Additional volumes to mount into the pod.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "volumeMounts": {
+      "type": "array",
+      "description": "Additional volume mounts for the container.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector for pod scheduling.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Tolerations for pod scheduling.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity rules for pod scheduling."
+    }
+  },
+  "required": ["agent", "replicaCount", "image"]
+}

--- a/charts/cofide-agent/values.schema.json
+++ b/charts/cofide-agent/values.schema.json
@@ -12,7 +12,9 @@
         "env": {
           "type": "object",
           "description": "Environment variables passed to the Cofide Agent container.",
-          "additionalProperties": false,
+          "additionalProperties": {
+            "type": "string"
+          },
           "properties": {
             "AGENT_PROFILE": {
               "type": "string",

--- a/charts/cofide-agent/values.yaml
+++ b/charts/cofide-agent/values.yaml
@@ -17,8 +17,24 @@ agent:
     AGENT_PROFILE: kubernetes
     AGENT_TOKEN: ""
     CLUSTER_ID: ""
+    # gRPC target (https://grpc.io/docs/guides/custom-name-resolution/) for Cofide Connect's mTLS endpoint, used for API calls after registration.
+    COFIDE_CONNECT_MTLS_GRPC_TARGET: ""
+    # Optional TLS server name override to use when verifying Cofide Connect's mTLS endpoint.
+    COFIDE_CONNECT_MTLS_SERVER_NAME: ""
+    # SPIFFE ID of Cofide Connect, used for both the mTLS and xDS connections.
+    COFIDE_CONNECT_SPIFFE_ID: ""
+    # gRPC target (https://grpc.io/docs/guides/custom-name-resolution/) for Cofide Connect's plain TLS endpoint, used when this agent registers the trust zone.
+    COFIDE_CONNECT_TLS_GRPC_TARGET: ""
+    # Optional TLS server name override to use when verifying Cofide Connect's plain TLS endpoint.
+    COFIDE_CONNECT_TLS_SERVER_NAME: ""
+    # DEPRECATED: use COFIDE_CONNECT_SPIFFE_ID instead.
     COFIDE_CONNECT_TRUST_DOMAIN: ""
+    # DEPRECATED: use COFIDE_CONNECT_TLS_GRPC_TARGET, COFIDE_CONNECT_MTLS_GRPC_TARGET and COFIDE_CONNECT_XDS_GRPC_TARGET instead.
     COFIDE_CONNECT_URL: ""
+    # gRPC target (https://grpc.io/docs/guides/custom-name-resolution/) for Cofide Connect's xDS server, used to fetch federated services config.
+    COFIDE_CONNECT_XDS_GRPC_TARGET: ""
+    # Optional TLS server name override to use when verifying Cofide Connect's xDS server.
+    COFIDE_CONNECT_XDS_SERVER_NAME: ""
     MANAGEMENT_ZONE: false
     OIDC_ENDPOINT_ENABLED: true
     TRUST_DOMAIN: ""


### PR DESCRIPTION
Helm chart now supports explicit values for:
- connect TLS gRPC target
- connect TLS server name (optional)
- connect MTLS gRPC target
- connect MTLS server name (optional)
- connect XDS gRPC target
- connect XDS server name (optional)
- connect SPIFFE ID

Deprecating:
- connect URL
- connect trust domain

Using the new values (with cofide-agent v0.58.0 or later) means the application makes no assumptions about the subdomain of the Connect API, the SNI that must be set when calling it or the path of its SPIFFE ID.