### PR TITLE
Improve chart image consistency

### DIFF
--- a/charts/cofide-agent/Chart.yaml
+++ b/charts/cofide-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-agent/templates/_helpers.tpl
+++ b/charts/cofide-agent/templates/_helpers.tpl
@@ -60,3 +60,27 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Full reference for an image, from a map of `registry`, `repository` and `tag`.
+Call with a dict of `image` (the map) and `defaultTag` (used when `tag` is empty).
+
+`registry` is optional: when empty the `repository` is used unqualified, so
+images can be pulled from Docker Hub.
+*/}}
+{{- define "cofide-agent.imageRef" -}}
+{{- $repository := .image.repository | required "A value for the image repository is required" -}}
+{{- $tag := .image.tag | default .defaultTag -}}
+{{- if .image.registry -}}
+{{- printf "%s/%s:%s" .image.registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Full image reference for the cofide-agent container. Defaults the tag to the chart appVersion.
+*/}}
+{{- define "cofide-agent.image" -}}
+{{- include "cofide-agent.imageRef" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) -}}
+{{- end }}

--- a/charts/cofide-agent/templates/deployment.yaml
+++ b/charts/cofide-agent/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
               name: cofide-agent
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "cofide-agent.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/cofide-agent/values.schema.json
+++ b/charts/cofide-agent/values.schema.json
@@ -169,7 +169,7 @@
       "properties": {
         "registry": {
           "type": "string",
-          "description": "Container image registry."
+          "description": "Container image registry. If empty, the repository is used unqualified."
         },
         "repository": {
           "type": "string",
@@ -185,7 +185,7 @@
           "description": "Image tag. Defaults to the chart's appVersion when empty."
         }
       },
-      "required": ["registry", "repository", "pullPolicy"]
+      "required": ["repository", "pullPolicy"]
     },
     "imagePullSecrets": {
       "type": "array",

--- a/charts/cofide-agent/values.yaml
+++ b/charts/cofide-agent/values.yaml
@@ -7,6 +7,7 @@ replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
+  # Container image registry. If empty, the repository is used unqualified.
   registry: 010438484483.dkr.ecr.eu-west-1.amazonaws.com
   repository: cofide/cofide-agent
   pullPolicy: IfNotPresent

--- a/charts/cofide-connect-ui/Chart.yaml
+++ b/charts/cofide-connect-ui/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.12
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect-ui/ci/mirrored-image-values.yaml
+++ b/charts/cofide-connect-ui/ci/mirrored-image-values.yaml
@@ -1,0 +1,17 @@
+ui:
+  hostname: ui.connect.example.org
+  connectUrl: https://api.connect.example.org
+  oauth:
+    clientId: cofide-connect-ui
+    issuer: https://idp.example.org
+
+image:
+  # Test an unqualified repository, pulled from Docker Hub.
+  registry: ""
+  repository: cofide/connect-ui
+
+envoy:
+  image:
+    # Test a repository that already includes a registry host, which takes
+    # precedence over image.registry.
+    repository: mirror.example.org/envoyproxy/envoy

--- a/charts/cofide-connect-ui/ci/required-values.yaml
+++ b/charts/cofide-connect-ui/ci/required-values.yaml
@@ -1,0 +1,10 @@
+ui:
+  # Hostname the UI is served on. Required.
+  hostname: ui.connect.example.org
+  # URL of the Cofide Connect API. Required.
+  connectUrl: https://api.connect.example.org
+  oauth:
+    # OAuth client ID for the UI. Required.
+    clientId: cofide-connect-ui
+    # Issuer of the IdP in use. Required.
+    issuer: https://idp.example.org

--- a/charts/cofide-connect-ui/templates/_helpers.tpl
+++ b/charts/cofide-connect-ui/templates/_helpers.tpl
@@ -24,6 +24,42 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Full reference for an image, from a map of `registry`, `repository` and `tag`.
+Call with a dict of `image` (the map) and `defaultTag` (used when `tag` is empty).
+
+Prefer `registry` + `repository`, matching the other Cofide charts. For backwards
+compatibility, a `repository` that already includes a registry host (its first
+path segment looks like a hostname, e.g. `example.com/cofide/connect-ui` or
+`localhost:5000/connect-ui`) is used as-is and `registry` is ignored.
+*/}}
+{{- define "cofide-connect-ui.imageRef" -}}
+{{- $repository := .image.repository | required "A value for the image repository is required" -}}
+{{- $tag := .image.tag | default .defaultTag -}}
+{{- $host := splitList "/" $repository | first -}}
+{{- if or (contains "." $host) (contains ":" $host) (eq $host "localhost") -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- else if .image.registry -}}
+{{- printf "%s/%s:%s" .image.registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Full image reference for the UI container. Defaults the tag to the chart appVersion.
+*/}}
+{{- define "cofide-connect-ui.image" -}}
+{{- include "cofide-connect-ui.imageRef" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) -}}
+{{- end }}
+
+{{/*
+Full image reference for the Envoy sidecar.
+*/}}
+{{- define "cofide-connect-ui.envoyImage" -}}
+{{- include "cofide-connect-ui.imageRef" (dict "image" .Values.envoy.image "defaultTag" "") -}}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "cofide-connect-ui.chart" -}}

--- a/charts/cofide-connect-ui/templates/deployment.yaml
+++ b/charts/cofide-connect-ui/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
       annotations:
         checksum/envoy-config: {{ include (print $.Template.BasePath "/configmap-envoy.yaml") . | sha256sum }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
       {{- with .Values.nodeSelector }}
@@ -55,7 +59,7 @@ spec:
             secretName: {{ .Values.envoy.tlsSecretName }}
       containers:
         - name: envoy-sidecar
-          image: "{{ .Values.envoy.image.repository }}:{{ .Values.envoy.image.tag }}"
+          image: "{{ include "cofide-connect-ui.envoyImage" . }}"
           imagePullPolicy: {{ .Values.envoy.image.pullPolicy }}
           command: ["envoy"]
           args: ["-c", "/etc/envoy/envoy.yaml", "--service-node", "$(POD_NAME)", "--service-cluster", "$(POD_NAMESPACE)"]
@@ -86,7 +90,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         - name: cofide-connect-ui
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "cofide-connect-ui.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             runAsNonRoot: true

--- a/charts/cofide-connect-ui/values.yaml
+++ b/charts/cofide-connect-ui/values.yaml
@@ -2,14 +2,17 @@
 
 replicaCount: 1
 
-# Container image configuration. Use `repository` and `tag` to point at the image
-# to deploy. `pullPolicy` controls the image pull behaviour.
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: 010438484483.dkr.ecr.eu-west-1.amazonaws.com/cofide/connect-ui
+  # Container image registry. If empty, the repository is used unqualified.
+  registry: 010438484483.dkr.ecr.eu-west-1.amazonaws.com
+  repository: cofide/connect-ui
+  pullPolicy: IfNotPresent
   # Defaults to chart appVersion if not set.
   tag: ""
-  pullPolicy: IfNotPresent
 
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
 # Override chart name
 nameOverride: ""
 fullnameOverride: ""
@@ -49,9 +52,10 @@ ui:
 # Envoy sidecar config used to proxy traffic to the UI
 envoy:
   image:
+    registry: docker.io
     repository: envoyproxy/envoy
-    tag: v1.33.14
     pullPolicy: IfNotPresent
+    tag: v1.33.14
   configMapName: connect-ui-envoy-config
   tlsSecretName: envoy-tls
   resources: {}

--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.23.0
+version: 0.23.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/Chart.yaml
+++ b/charts/cofide-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.23.1
+version: 0.24.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cofide-connect/ci/legacy-envoy-image-values.yaml
+++ b/charts/cofide-connect/ci/legacy-envoy-image-values.yaml
@@ -1,0 +1,17 @@
+connect:
+  urlBase: example.org
+
+envoy:
+  # Test the deprecated flat string form of envoy.image, retained for backwards
+  # compatibility with releases prior to the registry/repository/tag split.
+  #
+  # The registry and tag deliberately differ from the chart defaults so the
+  # rendered image proves the override was applied rather than silently
+  # dropped. Helm logs "cannot overwrite table with non table" here: it is
+  # discarding the default image map in favour of this string, as intended.
+  image: "mirror.example.org/envoyproxy/envoy:v1.32.0"
+  imagePullPolicy: Always
+  auth:
+    issuer: https://idp.example.org
+    jwksUri: https://idp.example.org/.well-known/jwks.json
+    tlsSecretName: connect-tls

--- a/charts/cofide-connect/templates/_helpers.tpl
+++ b/charts/cofide-connect/templates/_helpers.tpl
@@ -142,3 +142,30 @@ Full image reference for the cofide-connect container. Defaults the tag to the c
 {{- define "cofide-connect.image" -}}
 {{- include "cofide-connect.imageRef" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) -}}
 {{- end }}
+
+{{/*
+Full image reference for the Envoy sidecar.
+
+For backwards compatibility, `envoy.image` may still be set to a full image
+reference string (with the pull policy in `envoy.imagePullPolicy`) instead of a
+map of `registry`, `repository`, `pullPolicy` and `tag`.
+*/}}
+{{- define "cofide-connect.envoyImage" -}}
+{{- if kindIs "string" .Values.envoy.image -}}
+{{- .Values.envoy.image -}}
+{{- else -}}
+{{- include "cofide-connect.imageRef" (dict "image" .Values.envoy.image "defaultTag" "") -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Pull policy for the Envoy sidecar. Prefers `envoy.image.pullPolicy`, falling
+back to the deprecated `envoy.imagePullPolicy`.
+*/}}
+{{- define "cofide-connect.envoyImagePullPolicy" -}}
+{{- if kindIs "string" .Values.envoy.image -}}
+{{- .Values.envoy.imagePullPolicy | default "IfNotPresent" -}}
+{{- else -}}
+{{- .Values.envoy.image.pullPolicy | default .Values.envoy.imagePullPolicy | default "IfNotPresent" -}}
+{{- end -}}
+{{- end }}

--- a/charts/cofide-connect/templates/_helpers.tpl
+++ b/charts/cofide-connect/templates/_helpers.tpl
@@ -118,3 +118,27 @@ xds.{{ .Values.connect.urlBase }}
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Full reference for an image, from a map of `registry`, `repository` and `tag`.
+Call with a dict of `image` (the map) and `defaultTag` (used when `tag` is empty).
+
+`registry` is optional: when empty the `repository` is used unqualified, so
+images can be pulled from Docker Hub.
+*/}}
+{{- define "cofide-connect.imageRef" -}}
+{{- $repository := .image.repository | required "A value for the image repository is required" -}}
+{{- $tag := .image.tag | default .defaultTag -}}
+{{- if .image.registry -}}
+{{- printf "%s/%s:%s" .image.registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Full image reference for the cofide-connect container. Defaults the tag to the chart appVersion.
+*/}}
+{{- define "cofide-connect.image" -}}
+{{- include "cofide-connect.imageRef" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) -}}
+{{- end }}

--- a/charts/cofide-connect/templates/deployment.yaml
+++ b/charts/cofide-connect/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "cofide-connect.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             grpc:

--- a/charts/cofide-connect/templates/deployment.yaml
+++ b/charts/cofide-connect/templates/deployment.yaml
@@ -89,8 +89,8 @@ spec:
               mountPath: "/app/data"
             {{- end }}
         - name: envoy-sidecar
-          image: {{ .Values.envoy.image }}
-          imagePullPolicy: {{ .Values.envoy.imagePullPolicy }}
+          image: "{{ include "cofide-connect.envoyImage" . }}"
+          imagePullPolicy: {{ include "cofide-connect.envoyImagePullPolicy" . }}
           command: ["envoy"]
           args:
             - -c

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -7,6 +7,7 @@ replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/.
 image:
+  # Container image registry. If empty, the repository is used unqualified.
   registry: 010438484483.dkr.ecr.eu-west-1.amazonaws.com
   repository: cofide/connect-api
   pullPolicy: IfNotPresent

--- a/charts/cofide-connect/values.yaml
+++ b/charts/cofide-connect/values.yaml
@@ -206,9 +206,20 @@ connect:
   extraEnv: []
 
 envoy:
-  # Pinned to a specific non-floating version
-  image: "envoyproxy/envoy:v1.33.14"
-  imagePullPolicy: IfNotPresent
+  # For backwards compatibility, image may instead be set to a full reference
+  # string (with the pull policy in envoy.imagePullPolicy). Helm then logs
+  # "cannot overwrite table with non table for cofide-connect.envoy.image"
+  # because it discards the default map below in favour of the string; the
+  # string is still honoured. Prefer the map form to avoid the warning.
+  image:
+    # Container image registry. If empty, the repository is used unqualified.
+    registry: docker.io
+    # Container image repository.
+    repository: envoyproxy/envoy
+    # Image pull policy.
+    pullPolicy: IfNotPresent
+    # Pinned to a specific non-floating version.
+    tag: v1.33.14
   auth:
     # Issuer of the IdP in use.
     issuer: ""

--- a/charts/cofide-credex/Chart.yaml
+++ b/charts/cofide-credex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cofide-credex
 description: Helm chart to deploy Cofide Credex
 type: application
-version: 0.8.1
+version: 0.8.2
 appVersion: "v0.17.2"
 maintainers:
   - name: Cofide

--- a/charts/cofide-credex/templates/_helpers.tpl
+++ b/charts/cofide-credex/templates/_helpers.tpl
@@ -125,3 +125,27 @@ or as an entry in extraJWKSSources. Empty otherwise.
 true
 {{- end -}}
 {{- end -}}
+
+{{/*
+Full reference for an image, from a map of `registry`, `repository` and `tag`.
+Call with a dict of `image` (the map) and `defaultTag` (used when `tag` is empty).
+
+`registry` is optional: when empty the `repository` is used unqualified, so
+images can be pulled from Docker Hub.
+*/}}
+{{- define "cofide-credex.imageRef" -}}
+{{- $repository := .image.repository | required "A value for the image repository is required" -}}
+{{- $tag := .image.tag | default .defaultTag -}}
+{{- if .image.registry -}}
+{{- printf "%s/%s:%s" .image.registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Full image reference for the cofide-credex container. Defaults the tag to the chart appVersion.
+*/}}
+{{- define "cofide-credex.image" -}}
+{{- include "cofide-credex.imageRef" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) -}}
+{{- end }}

--- a/charts/cofide-credex/templates/deployment.yaml
+++ b/charts/cofide-credex/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "cofide-credex.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/cofide-credex/values.schema.json
+++ b/charts/cofide-credex/values.schema.json
@@ -16,7 +16,7 @@
       "properties": {
         "registry": {
           "type": "string",
-          "description": "Container image registry."
+          "description": "Container image registry. If empty, the repository is used unqualified."
         },
         "repository": {
           "type": "string",
@@ -32,7 +32,7 @@
           "description": "Image tag. Defaults to the chart's appVersion when empty."
         }
       },
-      "required": ["registry", "repository", "pullPolicy"]
+      "required": ["repository", "pullPolicy"]
     },
     "credex": {
       "type": "object",

--- a/charts/cofide-credex/values.yaml
+++ b/charts/cofide-credex/values.yaml
@@ -3,6 +3,7 @@ replicaCount: 1
 
 # Container image configuration.
 image:
+  # Container image registry. If empty, the repository is used unqualified.
   registry: 010438484483.dkr.ecr.eu-west-1.amazonaws.com
   repository: cofide/credex-exchange
   pullPolicy: IfNotPresent

--- a/charts/cofide-observer/Chart.yaml
+++ b/charts/cofide-observer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cofide-observer
 description: Helm chart to deploy Cofide Observer
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "v0.7.0"
 maintainers:
   - name: Cofide

--- a/charts/cofide-observer/templates/_helpers.tpl
+++ b/charts/cofide-observer/templates/_helpers.tpl
@@ -60,3 +60,27 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Full reference for an image, from a map of `registry`, `repository` and `tag`.
+Call with a dict of `image` (the map) and `defaultTag` (used when `tag` is empty).
+
+`registry` is optional: when empty the `repository` is used unqualified, so
+images can be pulled from Docker Hub.
+*/}}
+{{- define "cofide-observer.imageRef" -}}
+{{- $repository := .image.repository | required "A value for the image repository is required" -}}
+{{- $tag := .image.tag | default .defaultTag -}}
+{{- if .image.registry -}}
+{{- printf "%s/%s:%s" .image.registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Full image reference for the cofide-observer container. Defaults the tag to the chart appVersion.
+*/}}
+{{- define "cofide-observer.image" -}}
+{{- include "cofide-observer.imageRef" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) -}}
+{{- end }}

--- a/charts/cofide-observer/templates/deployment.yaml
+++ b/charts/cofide-observer/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
               name: {{ .Release.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "cofide-observer.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/charts/cofide-observer/values.schema.json
+++ b/charts/cofide-observer/values.schema.json
@@ -60,7 +60,7 @@
       "properties": {
         "registry": {
           "type": "string",
-          "description": "Container image registry."
+          "description": "Container image registry. If empty, the repository is used unqualified."
         },
         "repository": {
           "type": "string",
@@ -76,7 +76,7 @@
           "description": "Image tag. Defaults to the chart's appVersion when empty."
         }
       },
-      "required": ["registry", "repository", "pullPolicy"]
+      "required": ["repository", "pullPolicy"]
     },
     "imagePullSecrets": {
       "type": "array",

--- a/charts/cofide-observer/values.yaml
+++ b/charts/cofide-observer/values.yaml
@@ -23,6 +23,7 @@ replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
+  # Container image registry. If empty, the repository is used unqualified.
   registry: 010438484483.dkr.ecr.eu-west-1.amazonaws.com
   repository: cofide/cofide-observer
   # This sets the pull policy for images.

--- a/charts/cofide-trust-zone-operator/Chart.yaml
+++ b/charts/cofide-trust-zone-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cofide-trust-zone-operator
 description: Helm chart to deploy the Cofide Trust Zone Operator to a Kubernetes cluster
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "0.1.0"
 
 maintainers:

--- a/charts/cofide-trust-zone-operator/Chart.yaml
+++ b/charts/cofide-trust-zone-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cofide-trust-zone-operator
 description: Helm chart to deploy the Cofide Trust Zone Operator to a Kubernetes cluster
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 
 maintainers:

--- a/charts/cofide-trust-zone-operator/templates/_helpers.tpl
+++ b/charts/cofide-trust-zone-operator/templates/_helpers.tpl
@@ -63,3 +63,27 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Full reference for an image, from a map of `registry`, `repository` and `tag`.
+Call with a dict of `image` (the map) and `defaultTag` (used when `tag` is empty).
+
+`registry` is optional: when empty the `repository` is used unqualified, so
+images can be pulled from Docker Hub.
+*/}}
+{{- define "cofide-trust-zone-operator.imageRef" -}}
+{{- $repository := .image.repository | required "A value for the image repository is required" -}}
+{{- $tag := .image.tag | default .defaultTag -}}
+{{- if .image.registry -}}
+{{- printf "%s/%s:%s" .image.registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Full image reference for the cofide-trust-zone-operator container. Defaults the tag to the chart appVersion.
+*/}}
+{{- define "cofide-trust-zone-operator.image" -}}
+{{- include "cofide-trust-zone-operator.imageRef" (dict "image" .Values.trustZoneOperator.manager.image "defaultTag" .Chart.AppVersion) -}}
+{{- end }}

--- a/charts/cofide-trust-zone-operator/templates/deployment.yaml
+++ b/charts/cofide-trust-zone-operator/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if .Values.trustZoneOperator.manager.imagePullPolicy -}}
+{{- fail "trustZoneOperator.manager.imagePullPolicy has moved to trustZoneOperator.manager.image.pullPolicy" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -67,7 +70,7 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: "{{ include "cofide-trust-zone-operator.image" . }}"
-        imagePullPolicy: {{ .Values.trustZoneOperator.manager.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.trustZoneOperator.manager.image.pullPolicy }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/cofide-trust-zone-operator/templates/deployment.yaml
+++ b/charts/cofide-trust-zone-operator/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
           value: {{ quote .Values.trustZoneOperator.manager.env.spiffeEndpointSocket }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
-        image: {{ if .Values.trustZoneOperator.manager.image.registry }}{{ .Values.trustZoneOperator.manager.image.registry }}/{{ end }}{{ .Values.trustZoneOperator.manager.image.repository }}:{{ .Values.trustZoneOperator.manager.image.tag | default .Chart.AppVersion }}
+        image: "{{ include "cofide-trust-zone-operator.image" . }}"
         imagePullPolicy: {{ .Values.trustZoneOperator.manager.imagePullPolicy }}
         livenessProbe:
           httpGet:

--- a/charts/cofide-trust-zone-operator/values.schema.json
+++ b/charts/cofide-trust-zone-operator/values.schema.json
@@ -287,17 +287,17 @@
                   "type": "string",
                   "description": "Container image repository."
                 },
+                "pullPolicy": {
+                  "type": "string",
+                  "description": "Image pull policy.",
+                  "enum": ["Always", "IfNotPresent", "Never"]
+                },
                 "tag": {
                   "type": "string",
                   "description": "Container image tag. Defaults to the chart appVersion if empty."
                 }
               },
-              "required": ["repository"]
-            },
-            "imagePullPolicy": {
-              "type": "string",
-              "description": "Image pull policy.",
-              "enum": ["Always", "IfNotPresent", "Never"]
+              "required": ["repository", "pullPolicy"]
             },
             "env": {
               "type": "object",
@@ -319,7 +319,7 @@
               "description": "Security context for the manager container."
             }
           },
-          "required": ["image", "imagePullPolicy", "env"]
+          "required": ["image", "env"]
         },
         "podSecurityContext": {
           "type": "object",

--- a/charts/cofide-trust-zone-operator/values.schema.json
+++ b/charts/cofide-trust-zone-operator/values.schema.json
@@ -281,7 +281,7 @@
               "properties": {
                 "registry": {
                   "type": "string",
-                  "description": "Container image registry."
+                  "description": "Container image registry. If empty, the repository is used unqualified."
                 },
                 "repository": {
                   "type": "string",
@@ -292,7 +292,7 @@
                   "description": "Container image tag. Defaults to the chart appVersion if empty."
                 }
               },
-              "required": ["registry", "repository"]
+              "required": ["repository"]
             },
             "imagePullPolicy": {
               "type": "string",

--- a/charts/cofide-trust-zone-operator/values.yaml
+++ b/charts/cofide-trust-zone-operator/values.yaml
@@ -154,7 +154,7 @@ trustZoneOperator:
   # Configuration for the manager container.
   manager:
     image:
-      # Container image registry.
+      # Container image registry. If empty, the repository is used unqualified.
       registry: 010438484483.dkr.ecr.eu-west-1.amazonaws.com
       # Container image repository.
       repository: cofide/trust-zone-operator

--- a/charts/cofide-trust-zone-operator/values.yaml
+++ b/charts/cofide-trust-zone-operator/values.yaml
@@ -158,11 +158,10 @@ trustZoneOperator:
       registry: 010438484483.dkr.ecr.eu-west-1.amazonaws.com
       # Container image repository.
       repository: cofide/trust-zone-operator
+      # Image pull policy.
+      pullPolicy: IfNotPresent
       # Container image tag. Defaults to the chart appVersion if empty.
       tag: ""
-
-    # Image pull policy.
-    imagePullPolicy: IfNotPresent
 
     # Additional arguments to pass to the manager binary. The chart appends --health-probe-bind-address,
     # --connect-url, --connect-trust-domain, --gateway-namespace, --gateway-base-domain,

--- a/charts/spiffe-enable/Chart.yaml
+++ b/charts/spiffe-enable/Chart.yaml
@@ -3,7 +3,7 @@ name: spiffe-enable
 description: Helm chart for the spiffe-enable admission webhook for Kubernetes
 type: application
 
-version: 0.1.9
+version: 0.1.10
 
 appVersion: "v0.5.3"
 

--- a/charts/spiffe-enable/templates/_helpers.tpl
+++ b/charts/spiffe-enable/templates/_helpers.tpl
@@ -71,3 +71,27 @@ Return the appropriate apiVersion for cert-manager resources.
 {{- define "cert-manager.apiVersion" -}}
 {{- print "cert-manager.io/v1" -}}
 {{- end -}}
+
+{{/*
+Full reference for an image, from a map of `registry`, `repository` and `tag`.
+Call with a dict of `image` (the map) and `defaultTag` (used when `tag` is empty).
+
+`registry` is optional: when empty the `repository` is used unqualified, so
+images can be pulled from Docker Hub.
+*/}}
+{{- define "spiffe-enable.imageRef" -}}
+{{- $repository := .image.repository | required "A value for the image repository is required" -}}
+{{- $tag := .image.tag | default .defaultTag -}}
+{{- if .image.registry -}}
+{{- printf "%s/%s:%s" .image.registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Full image reference for the spiffe-enable container. Defaults the tag to the chart appVersion.
+*/}}
+{{- define "spiffe-enable.image" -}}
+{{- include "spiffe-enable.imageRef" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) -}}
+{{- end }}

--- a/charts/spiffe-enable/templates/deployment.yaml
+++ b/charts/spiffe-enable/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: {{ .Values.webhook.appName }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "spiffe-enable.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: https-webhook

--- a/charts/spiffe-enable/values.yaml
+++ b/charts/spiffe-enable/values.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 image:
+  # Container image registry. If empty, the repository is used unqualified.
   registry: ghcr.io
   repository: cofide/spiffe-enable
   pullPolicy: IfNotPresent


### PR DESCRIPTION
- **Make cofide-connect-ui image values consistent with other charts**
    Split image.repository into image.registry + image.repository, matching
    cofide-agent, cofide-connect, cofide-credex, cofide-observer and
    spiffe-enable, and give the Envoy sidecar the same shape so both images
    in the chart are configured identically.
    
    A repository that already includes a registry host is still honoured and
    takes precedence over image.registry, so existing values keep working.
    
    Also adds imagePullSecrets, which every other chart already supported,
    and ci/ values files so ct lint renders the chart at all: its templates
    use fail() for required values, which helm lint downgrades to INFO,
    meaning the deployment was never actually templated in CI.
    
    Note the default Envoy image string gains a docker.io/ prefix, so
    existing releases will roll the sidecar once on upgrade.

- **Fix invalid image reference when image.registry is empty**
    Every chart interpolated the image as "{{ .Values.image.registry }}/{{
    .Values.image.repository }}", so clearing image.registry to pull from
    Docker Hub produced "/cofide/foo:v1" — an invalid reference. Only
    cofide-trust-zone-operator guarded against it.
    
    Each chart now renders its image through a <chart>.imageRef helper that
    omits the registry when it is empty. Helm has no cross-chart template
    sharing without a library chart, so the helper is duplicated per chart;
    in exchange every deployment's image line is now identical.
    
    The helper deliberately does not detect a registry host inside
    repository, unlike cofide-connect-ui's. These charts always prefixed the
    registry unconditionally, so a host in repository rendered as
    "registry/host/path" and could never have worked — there is nothing to
    stay compatible with.
    
    Drops "registry" from the required list in the cofide-credex and
    cofide-trust-zone-operator values schemas, which previously rejected an
    absent registry before the template ever ran. This is a relaxation only,
    so existing values remain valid.

- **Give the cofide-connect Envoy sidecar a structured image value**
    envoy.image was a flat "envoyproxy/envoy:v1.33.14" string with the pull
    policy alongside it as envoy.imagePullPolicy, the only image in the repo
    shaped that way. It could not be repointed at a mirror without restating
    the tag, which matters for air-gapped installs and pull-through caches.
    
    It is now a map of registry, repository, pullPolicy and tag, matching the
    main image and cofide-connect-ui's sidecar. The old string form still
    works: envoyImage detects it with kindIs and falls back to
    envoy.imagePullPolicy, covered by ci/legacy-envoy-image-values.yaml.
    
    The default rendered image gains a docker.io/ prefix, so existing
    releases will roll the sidecar once on upgrade.
- **Move the trust-zone-operator pull policy into its image map**
    trustZoneOperator.manager.imagePullPolicy sat outside the image map,
    unlike every other chart where it is image.pullPolicy. It is now
    trustZoneOperator.manager.image.pullPolicy, in both values.yaml and the
    values schema.
    
    This is a breaking values change with no fallback. The schema does not
    set additionalProperties: false on the manager block, so the old key
    would have been silently ignored — a pull policy that looks applied but
    is not. The template now fails with a message naming the new key
    instead. Worth removing once users have migrated.
