### PR TITLE
Support explicit Connect config in cofide-trust-zone-operator chart

### DIFF
--- a/charts/cofide-trust-zone-operator/Chart.yaml
+++ b/charts/cofide-trust-zone-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cofide-trust-zone-operator
 description: Helm chart to deploy the Cofide Trust Zone Operator to a Kubernetes cluster
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.1"
 
 maintainers:
   - name: Cofide

--- a/charts/cofide-trust-zone-operator/ci/mtls-values.yaml
+++ b/charts/cofide-trust-zone-operator/ci/mtls-values.yaml
@@ -1,0 +1,13 @@
+connect:
+  # Test new mTLS/TLS gRPC target / SPIFFE ID connect fields.
+  mtlsGrpcTarget: connect.example.org:8443
+  mtlsServerName: connect.example.org
+  spiffeId: spiffe://example.org/connect
+  tlsGrpcTarget: connect.example.org:8444
+  tlsServerName: connect.example.org
+
+gateway:
+  # Base domain for Gateway API TLSRoutes. Required.
+  baseDomain: example.org
+  # Name of the GatewayClass to use. Required.
+  className: eg

--- a/charts/cofide-trust-zone-operator/templates/NOTES.txt
+++ b/charts/cofide-trust-zone-operator/templates/NOTES.txt
@@ -5,9 +5,17 @@ Verify the operator is running:
   kubectl get deployment {{ include "cofide-trust-zone-operator.fullname" . }} -n {{ .Release.Namespace }}
 
 NOTE: The operator requires the CRDs from the cofide-tzaas-crds chart to be installed separately before use.
-{{- if or (not .Values.connect.url) (not .Values.connect.trustDomain) }}
+{{- if or (and (not .Values.connect.url) (not .Values.connect.mtlsGrpcTarget)) (and (not .Values.connect.trustDomain) (not .Values.connect.spiffeId)) }}
 
-WARNING: Connect integration is not configured. Set connect.url and connect.trustDomain to enable it.
+WARNING: Connect integration is not configured. Set connect.mtlsGrpcTarget and connect.spiffeId to enable it.
+{{- end }}
+{{- if .Values.connect.url }}
+
+WARNING: connect.url is deprecated, use connect.mtlsGrpcTarget and connect.tlsGrpcTarget instead.
+{{- end }}
+{{- if .Values.connect.trustDomain }}
+
+WARNING: connect.trustDomain is deprecated, use connect.spiffeId instead.
 {{- end }}
 {{- if not .Values.gateway.baseDomain }}
 

--- a/charts/cofide-trust-zone-operator/templates/deployment.yaml
+++ b/charts/cofide-trust-zone-operator/templates/deployment.yaml
@@ -38,6 +38,21 @@ spec:
       {{- if .Values.connect.trustDomain }}
       {{- $args = append $args (printf "--connect-trust-domain=%s" .Values.connect.trustDomain) }}
       {{- end }}
+      {{- if .Values.connect.mtlsGrpcTarget }}
+      {{- $args = append $args (printf "--connect-mtls-grpc-target=%s" .Values.connect.mtlsGrpcTarget) }}
+      {{- end }}
+      {{- if .Values.connect.mtlsServerName }}
+      {{- $args = append $args (printf "--connect-mtls-server-name=%s" .Values.connect.mtlsServerName) }}
+      {{- end }}
+      {{- if .Values.connect.spiffeId }}
+      {{- $args = append $args (printf "--connect-spiffe-id=%s" .Values.connect.spiffeId) }}
+      {{- end }}
+      {{- if .Values.connect.tlsGrpcTarget }}
+      {{- $args = append $args (printf "--connect-tls-grpc-target=%s" .Values.connect.tlsGrpcTarget) }}
+      {{- end }}
+      {{- if .Values.connect.tlsServerName }}
+      {{- $args = append $args (printf "--connect-tls-server-name=%s" .Values.connect.tlsServerName) }}
+      {{- end }}
       {{- if .Values.connect.bundleUrl }}
       {{- $args = append $args (printf "--connect-bundle-url=%s" .Values.connect.bundleUrl) }}
       {{- end }}

--- a/charts/cofide-trust-zone-operator/values.schema.json
+++ b/charts/cofide-trust-zone-operator/values.schema.json
@@ -30,13 +30,31 @@
       "properties": {
         "url": {
           "type": "string",
-          "description": "URL of the Connect instance. Required for Connect integration.",
-          "minLength": 1
+          "description": "DEPRECATED: use mtlsGrpcTarget instead. URL of the Connect instance."
+        },
+        "mtlsGrpcTarget": {
+          "type": "string",
+          "description": "gRPC target for Connect's mTLS endpoint, used by the operator itself. One of mtlsGrpcTarget or url is required."
+        },
+        "mtlsServerName": {
+          "type": "string",
+          "description": "Optional SNI override to use when verifying Connect's mTLS endpoint."
+        },
+        "tlsGrpcTarget": {
+          "type": "string",
+          "description": "gRPC target for Connect's plain TLS endpoint, passed through to the SPIRE servers deployed via the generated TrustZoneServer resources."
+        },
+        "tlsServerName": {
+          "type": "string",
+          "description": "Optional SNI override for the plain TLS endpoint, passed through to the deployed SPIRE servers."
         },
         "trustDomain": {
           "type": "string",
-          "description": "Trust domain of the Connect instance. Required for Connect integration.",
-          "minLength": 1
+          "description": "DEPRECATED: use spiffeId instead. Trust domain of the Connect instance."
+        },
+        "spiffeId": {
+          "type": "string",
+          "description": "SPIFFE ID of the Connect instance. One of spiffeId or trustDomain is required."
         },
         "cluster": {
           "type": "object",

--- a/charts/cofide-trust-zone-operator/values.yaml
+++ b/charts/cofide-trust-zone-operator/values.yaml
@@ -33,10 +33,20 @@ operator:
 
 # Connect control plane configuration.
 connect:
-  # URL of the Connect instance.
+  # DEPRECATED: use connect.mtlsGrpcTarget and connect.tlsGrpcTarget instead. URL of the Connect instance.
   url: ""
-  # Trust domain of the Connect instance.
+  # gRPC target (https://grpc.io/docs/guides/custom-name-resolution) for Connect's mTLS endpoint, used by the operator itself. One of connect.mtlsGrpcTarget or connect.url is recommended.
+  mtlsGrpcTarget: ""
+  # Optional TLS server name override to use when verifying Connect's mTLS endpoint.
+  mtlsServerName: ""
+  # gRPC target for Connect's plain TLS endpoint, passed through to the SPIRE servers deployed via the generated TrustZoneServer resources.
+  tlsGrpcTarget: ""
+  # Optional TLS server name override for the plain TLS endpoint, passed through to the deployed SPIRE servers.
+  tlsServerName: ""
+  # DEPRECATED: use connect.spiffeId instead. Trust domain of the Connect instance.
   trustDomain: ""
+  # SPIFFE ID of the Connect instance. One of connect.spiffeId or connect.trustDomain is recommended.
+  spiffeId: ""
   # URL of the Connect bundle endpoint.
   bundleUrl: ""
   # Configuration identifying the cluster this operator manages.
@@ -165,8 +175,9 @@ trustZoneOperator:
     imagePullPolicy: IfNotPresent
 
     # Additional arguments to pass to the manager binary. The chart appends --health-probe-bind-address,
-    # --connect-url, --connect-trust-domain, --gateway-namespace, --gateway-base-domain,
-    # --leader-elect (if leaderElection.enabled), --metrics-bind-address/--metrics-secure
+    # --connect-url, --connect-trust-domain, --connect-mtls-grpc-target, --connect-mtls-server-name,
+    # --connect-spiffe-id, --connect-tls-grpc-target, --connect-tls-server-name, --gateway-namespace,
+    # --gateway-base-domain, --leader-elect (if leaderElection.enabled), --metrics-bind-address/--metrics-secure
     # (if metrics.enabled), and --metrics-cert-path (if metrics.tls.enabled and metrics.tls.certSecretName is set) automatically.
     args: []
 


### PR DESCRIPTION
Support explicit Connect config in cofide-trust-zone-operator chart

Helm chart now supports explicit values for:
- connect TLS gRPC target
- connect TLS server name (optional)
- connect MTLS gRPC target
- connect MTLS server name (optional)
- connect SPIFFE ID

Deprecating:
- connect URL
- connect trust domain

Using the new values (with trust-zone-operator v0.2.0 or later) means the application makes no assumptions about the subdomain of the Connect API, the SNI that must be set when calling it or the path of its SPIFFE ID.