### PR TITLE
Support explicit config for Connect in cofide-credex chart

### DIFF
--- a/charts/cofide-credex/Chart.yaml
+++ b/charts/cofide-credex/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cofide-credex
 description: Helm chart to deploy Cofide Credex
 type: application
-version: 0.8.1
-appVersion: "v0.17.2"
+version: 0.9.0
+appVersion: "v0.18.0"
 maintainers:
   - name: Cofide
     url: https://cofide.io

--- a/charts/cofide-credex/README.md
+++ b/charts/cofide-credex/README.md
@@ -31,8 +31,8 @@ When the local signer is not in use (`credex.signing.method=spire` and `local` i
 helm install cofide-credex cofide/cofide-credex \
   --namespace cofide \
   --set credex.issuerURL=https://credex.example.org \
-  --set credex.connectURL=connect.example.org:443 \
-  --set credex.connectTrustDomain=example.org
+  --set credex.connectMTLSGRPCTarget=connect.example.org:8443 \
+  --set credex.connectSPIFFEID=spiffe://example.org/connect
 ```
 
 ## Configuration
@@ -43,9 +43,12 @@ helm install cofide-credex cofide/cofide-credex \
 |---|---|---|
 | `credex.issuerURL` | Issuer URL advertised in the OAuth AS metadata | Yes |
 | `credex.accessTokenLifetime` | Token lifetime, e.g. `5m`, `1h`. Defaults to 1 minute | No |
-| `credex.policyConfigFile` | Path to a local policy config file. Mutually exclusive with `connectURL` | One of |
-| `credex.connectURL` | Host:port of the Cofide Connect service used as the policy store. Mutually exclusive with `policyConfigFile` | One of |
-| `credex.connectTrustDomain` | SPIFFE trust domain of the Cofide Connect service. Required when `connectURL` is set | Conditional |
+| `credex.policyConfigFile` | Path to a local policy config file. Mutually exclusive with `connectURL`/`connectMTLSGRPCTarget` | One of |
+| `credex.connectMTLSGRPCTarget` | gRPC target for Cofide Connect's mTLS endpoint, used as the policy store and/or audit backend. Mutually exclusive with `policyConfigFile` | One of |
+| `credex.connectMTLSServerName` | Optional TLS SNI override to use when verifying Cofide Connect's mTLS endpoint | No |
+| `credex.connectSPIFFEID` | SPIFFE ID of the Cofide Connect service. Required when `connectMTLSGRPCTarget` is set | Conditional |
+| `credex.connectURL` | DEPRECATED: use `connectMTLSGRPCTarget` instead. Host:port of the Cofide Connect service used as the policy store. Mutually exclusive with `policyConfigFile` | One of |
+| `credex.connectTrustDomain` | DEPRECATED: use `connectSPIFFEID` instead. SPIFFE trust domain of the Cofide Connect service. Required when `connectURL` is set | Conditional |
 
 ### Signing Keys
 

--- a/charts/cofide-credex/ci/mtls-values.yaml
+++ b/charts/cofide-credex/ci/mtls-values.yaml
@@ -1,0 +1,7 @@
+credex:
+  issuerURL: https://credex.example.org
+  # Test new mTLS gRPC target / SPIFFE ID connect fields.
+  connectMTLSGRPCTarget: connect.example.org:8443
+  connectMTLSServerName: connect.example.org
+  connectSPIFFEID: spiffe://example.org/connect
+  preflightChecks: false

--- a/charts/cofide-credex/templates/NOTES.txt
+++ b/charts/cofide-credex/templates/NOTES.txt
@@ -8,3 +8,11 @@ To view logs:
 
 To access the service within the cluster:
   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "cofide-credex.fullname" . }} 8080:{{ .Values.service.port }}
+{{- if .Values.credex.connectURL }}
+
+WARNING: credex.connectURL is deprecated, use credex.connectMTLSGRPCTarget instead.
+{{- end }}
+{{- if .Values.credex.connectTrustDomain }}
+
+WARNING: credex.connectTrustDomain is deprecated, use credex.connectSPIFFEID instead.
+{{- end }}

--- a/charts/cofide-credex/templates/configmap.yaml
+++ b/charts/cofide-credex/templates/configmap.yaml
@@ -44,8 +44,20 @@ data:
   {{- with .Values.credex.connectURL }}
   CONNECT_URL: {{ . | quote }}
   {{- end }}
+  {{- if and .Values.credex.connectMTLSGRPCTarget (not .Values.credex.connectSPIFFEID) (not .Values.credex.connectTrustDomain) }}
+  {{- fail "credex.connectSPIFFEID (or the deprecated credex.connectTrustDomain) must be set when credex.connectMTLSGRPCTarget is set" }}
+  {{- end }}
+  {{- with .Values.credex.connectMTLSGRPCTarget }}
+  CONNECT_MTLS_GRPC_TARGET: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.credex.connectMTLSServerName }}
+  CONNECT_MTLS_SERVER_NAME: {{ . | quote }}
+  {{- end }}
   {{- with .Values.credex.connectTrustDomain }}
   CONNECT_TRUST_DOMAIN: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.credex.connectSPIFFEID }}
+  CONNECT_SPIFFE_ID: {{ . | quote }}
   {{- end }}
   {{- range $i, $issuer := .Values.credex.trustedIssuers }}
   {{ printf "TRUSTED_ISSUER_%d" (add1 $i) }}: {{ $issuer.issuer | quote }}

--- a/charts/cofide-credex/values.schema.json
+++ b/charts/cofide-credex/values.schema.json
@@ -192,7 +192,7 @@
           "properties": {
             "backend": {
               "type": "string",
-              "description": "Audit backend type. Supported values: \"log\" (logging to stdout), \"connect\" (sending to Cofide Connect service; requires setting credex.connectURL).",
+              "description": "Audit backend type. Supported values: \"log\" (logging to stdout), \"connect\" (sending to Cofide Connect service; requires setting credex.connectURL or credex.connectMTLSGRPCTarget).",
               "enum": ["log", "connect"]
             }
           },
@@ -226,15 +226,27 @@
         },
         "policyConfigFile": {
           "type": "string",
-          "description": "Path to a YAML file containing exchange policies. Mutually exclusive with connectURL. One of policyConfigFile or connectURL must be set when enableOAuthAS is true."
+          "description": "Path to a YAML file containing exchange policies. Mutually exclusive with connectURL/connectMTLSGRPCTarget. One of policyConfigFile, connectURL or connectMTLSGRPCTarget must be set when enableOAuthAS is true."
         },
         "connectURL": {
           "type": "string",
-          "description": "Host:port of the Cofide Connect service used as the exchange policy store. Mutually exclusive with policyConfigFile. One of policyConfigFile or connectURL must be set when enableOAuthAS is true."
+          "description": "DEPRECATED: use connectMTLSGRPCTarget instead. Host:port of the Cofide Connect service used as the exchange policy store and/or audit backend. Mutually exclusive with policyConfigFile."
+        },
+        "connectMTLSGRPCTarget": {
+          "type": "string",
+          "description": "gRPC target for Cofide Connect's mTLS endpoint, used as the exchange policy store and/or audit backend. Mutually exclusive with policyConfigFile. One of policyConfigFile, connectURL or connectMTLSGRPCTarget must be set when enableOAuthAS is true."
+        },
+        "connectMTLSServerName": {
+          "type": "string",
+          "description": "Optional TLS SNI override to use when verifying Cofide Connect's mTLS endpoint."
         },
         "connectTrustDomain": {
           "type": "string",
-          "description": "SPIFFE trust domain of the Cofide Connect service. Required when connectURL is set."
+          "description": "DEPRECATED: use connectSPIFFEID instead. SPIFFE trust domain of the Cofide Connect service. Required when connectURL is set."
+        },
+        "connectSPIFFEID": {
+          "type": "string",
+          "description": "SPIFFE ID of the Cofide Connect service. Required when connectMTLSGRPCTarget is set."
         },
         "extraCA": {
           "type": "string",
@@ -296,7 +308,8 @@
             "required": ["issuerURL"],
             "anyOf": [
               { "properties": { "policyConfigFile": { "type": "string", "minLength": 1 } } },
-              { "properties": { "connectURL": { "type": "string", "minLength": 1 } } }
+              { "properties": { "connectURL": { "type": "string", "minLength": 1 } } },
+              { "properties": { "connectMTLSGRPCTarget": { "type": "string", "minLength": 1 } } }
             ]
           }
         },

--- a/charts/cofide-credex/values.yaml
+++ b/charts/cofide-credex/values.yaml
@@ -73,7 +73,7 @@ credex:
     targetSPIFFEID: ""
   # Audit configuration.
   audit:
-    # Audit backend type. Supported values: "log" (logging to stdout), "connect" (sending to Cofide Connect service; requires setting credex.connectURL).
+    # Audit backend type. Supported values: "log" (logging to stdout), "connect" (sending to Cofide Connect service; requires setting credex.connectURL or credex.connectMTLSGRPCTarget).
     backend: connect
   # Trusted issuers for token exchange. Each entry generates a numbered set of
   # TRUSTED_ISSUER_n / TRUSTED_ISSUER_JWKS_URL_n / TRUSTED_ISSUER_ALLOWED_AUDIENCES_n env vars.
@@ -81,14 +81,23 @@ credex:
   # - issuer: ""
   #   jwksURL: ""
   #   allowedAudiences: []
-  # Path to a YAML file containing exchange policies. Mutually exclusive with connectURL.
-  # One of policyConfigFile or connectURL must be set when enableOAuthAS is true.
+  # Path to a YAML file containing exchange policies. Mutually exclusive with connectURL/connectMTLSGRPCTarget.
+  # One of policyConfigFile, connectURL or connectMTLSGRPCTarget must be set when enableOAuthAS is true.
   policyConfigFile: ""
-  # Host:port of the Cofide Connect service used as the exchange policy store.
-  # One of policyConfigFile or connectURL must be set when enableOAuthAS is true.
+  # DEPRECATED: use connectMTLSGRPCTarget instead. Host:port of the Cofide Connect service used
+  # as the exchange policy store and/or audit backend.
   connectURL: ""
-  # SPIFFE trust domain of the Cofide Connect service. Required when connectURL is set.
+  # gRPC target (https://grpc.io/docs/guides/custom-name-resolution) for Cofide Connect's mTLS
+  # endpoint, used as the exchange policy store and/or audit backend. One of policyConfigFile,
+  # connectURL or connectMTLSGRPCTarget must be set when enableOAuthAS is true.
+  connectMTLSGRPCTarget: ""
+  # Optional TLS SNI override to use when verifying Cofide Connect's mTLS endpoint.
+  connectMTLSServerName: ""
+  # DEPRECATED: use connectSPIFFEID instead. SPIFFE trust domain of the Cofide Connect service.
+  # Required when connectURL is set.
   connectTrustDomain: ""
+  # SPIFFE ID of the Cofide Connect service. Required when connectMTLSGRPCTarget is set.
+  connectSPIFFEID: ""
   # PEM-encoded CA certificate. When non-empty, creates a cofide-credex-extra-ca ConfigMap
   # and mounts it at /etc/ssl/certs/extra-ca.crt.
   extraCA: ""


### PR DESCRIPTION
Helm chart now supports explicit values for:
- connect MTLS gRPC target
- connect MTLS server name (optional)
- connect SPIFFE ID

Deprecating:
- connect URL
- connect trust domain